### PR TITLE
Profile drop down, change password page

### DIFF
--- a/frontend/src/pages/dashboard/crud-dashboard/CrudDashboard.tsx
+++ b/frontend/src/pages/dashboard/crud-dashboard/CrudDashboard.tsx
@@ -1,15 +1,16 @@
-import NotificationsProvider from './hooks/useNotifications/NotificationsProvider';
-import DialogsProvider from './hooks/useDialogs/DialogsProvider';
-import { Routes, Route } from 'react-router-dom';
-import DashboardLayout from './components/DashboardLayout';
-import BookList from './components/BookList';
-import BookShow from './components/BookShow';
+import { Route, Routes } from 'react-router-dom';
 import BookCreate from './components/BookCreate';
 import BookEdit from './components/BookEdit';
-import EmployeeList from './components/EmployeeList';
-import EmployeeShow from './components/EmployeeShow';
+import BookList from './components/BookList';
+import BookShow from './components/BookShow';
+import ChangePassword from './components/ChangePassword';
+import DashboardLayout from './components/DashboardLayout';
 import EmployeeCreate from './components/EmployeeCreate';
 import EmployeeEdit from './components/EmployeeEdit';
+import EmployeeList from './components/EmployeeList';
+import EmployeeShow from './components/EmployeeShow';
+import DialogsProvider from './hooks/useDialogs/DialogsProvider';
+import NotificationsProvider from './hooks/useNotifications/NotificationsProvider';
 
 export default function CrudDashboard() {
   return (
@@ -26,6 +27,7 @@ export default function CrudDashboard() {
             <Route path="employees/new" element={<EmployeeCreate />} />
             <Route path="employees/:employeeId" element={<EmployeeShow />} />
             <Route path="employees/:employeeId/edit" element={<EmployeeEdit />} />
+            <Route path="change-password" element={<ChangePassword />} />
           </Route>
         </Routes>
       </DialogsProvider>

--- a/frontend/src/pages/dashboard/crud-dashboard/components/ChangePassword.tsx
+++ b/frontend/src/pages/dashboard/crud-dashboard/components/ChangePassword.tsx
@@ -1,0 +1,163 @@
+import * as React from 'react';
+import { useNavigate } from 'react-router-dom';
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import FormControl from '@mui/material/FormControl';
+import FormLabel from '@mui/material/FormLabel';
+import Grid from '@mui/material/Grid';
+import Stack from '@mui/material/Stack';
+import TextField from '@mui/material/TextField';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import PageContainer from './PageContainer';
+import useNotifications from '../hooks/useNotifications/useNotifications';
+import { useAuth } from '../../../../context/AuthContext';
+
+export default function ChangePassword() {
+  const navigate = useNavigate();
+  const notifications = useNotifications();
+  const { changePassword } = useAuth();
+
+  const [currentPassword, setCurrentPassword] = React.useState('');
+  const [newPassword, setNewPassword] = React.useState('');
+  const [confirmPassword, setConfirmPassword] = React.useState('');
+  const [isSubmitting, setIsSubmitting] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+
+  // Client-side validation
+  const passwordIsTooShort = newPassword.length > 0 && newPassword.length < 8;
+  const passwordsDoNotMatch = confirmPassword.length > 0 && newPassword !== confirmPassword;
+
+  const formIsValid =
+    currentPassword.length > 0 &&
+    newPassword.length > 0 &&
+    confirmPassword.length > 0 &&
+    !passwordIsTooShort &&
+    !passwordsDoNotMatch;
+
+  const handleSubmit = React.useCallback(
+    async (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      setError(null);
+
+      if (!formIsValid) return;
+
+      setIsSubmitting(true);
+      try {
+        await changePassword(currentPassword, newPassword, confirmPassword);
+
+        notifications.show('Password changed successfully.', {
+          severity: 'success',
+          autoHideDuration: 3000,
+        });
+
+        // Clear form and navigate back
+        setCurrentPassword('');
+        setNewPassword('');
+        setConfirmPassword('');
+        navigate('/dashboard');
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'Failed to change password.';
+        setError(message);
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [
+      formIsValid,
+      currentPassword,
+      newPassword,
+      confirmPassword,
+      changePassword,
+      notifications,
+      navigate,
+    ],
+  );
+
+  const handleBack = React.useCallback(() => {
+    navigate('/dashboard');
+  }, [navigate]);
+
+  return (
+    <PageContainer title="Change Password" breadcrumbs={[{ title: 'Change Password' }]}>
+      <Box
+        component="form"
+        onSubmit={handleSubmit}
+        noValidate
+        sx={{ width: '100%', maxWidth: 600 }}
+      >
+        {error && (
+          <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>
+            {error}
+          </Alert>
+        )}
+
+        <Grid container spacing={2} sx={{ mb: 2 }}>
+          <Grid size={{ xs: 12 }}>
+            <FormControl fullWidth>
+              <FormLabel htmlFor="current-password">Current Password</FormLabel>
+              <TextField
+                id="current-password"
+                type="password"
+                autoComplete="current-password"
+                value={currentPassword}
+                onChange={(e) => setCurrentPassword(e.target.value)}
+                fullWidth
+                required
+              />
+            </FormControl>
+          </Grid>
+
+          <Grid size={{ xs: 12 }}>
+            <FormControl fullWidth>
+              <FormLabel htmlFor="new-password">New Password</FormLabel>
+              <TextField
+                id="new-password"
+                type="password"
+                autoComplete="new-password"
+                value={newPassword}
+                onChange={(e) => setNewPassword(e.target.value)}
+                error={passwordIsTooShort}
+                helperText={passwordIsTooShort ? 'Password must be at least 8 characters.' : ' '}
+                fullWidth
+                required
+              />
+            </FormControl>
+          </Grid>
+
+          <Grid size={{ xs: 12 }}>
+            <FormControl fullWidth>
+              <FormLabel htmlFor="confirm-password">Confirm New Password</FormLabel>
+              <TextField
+                id="confirm-password"
+                type="password"
+                autoComplete="new-password"
+                value={confirmPassword}
+                onChange={(e) => setConfirmPassword(e.target.value)}
+                error={passwordsDoNotMatch}
+                helperText={passwordsDoNotMatch ? 'Passwords do not match.' : ' '}
+                fullWidth
+                required
+              />
+            </FormControl>
+          </Grid>
+        </Grid>
+
+        <Stack direction="row" spacing={2} justifyContent="space-between">
+          <Button variant="contained" startIcon={<ArrowBackIcon />} onClick={handleBack}>
+            Back
+          </Button>
+          <Button
+            type="submit"
+            variant="contained"
+            size="large"
+            disabled={!formIsValid || isSubmitting}
+            loading={isSubmitting}
+          >
+            Change Password
+          </Button>
+        </Stack>
+      </Box>
+    </PageContainer>
+  );
+}

--- a/frontend/src/pages/dashboard/crud-dashboard/components/DashboardSidebar.tsx
+++ b/frontend/src/pages/dashboard/crud-dashboard/components/DashboardSidebar.tsx
@@ -1,6 +1,3 @@
-import * as React from 'react';
-import { useTheme } from '@mui/material/styles';
-import useMediaQuery from '@mui/material/useMediaQuery';
 import Box from '@mui/material/Box';
 import Drawer from '@mui/material/Drawer';
 import List from '@mui/material/List';
@@ -8,22 +5,30 @@ import ListItem from '@mui/material/ListItem';
 import ListItemButton from '@mui/material/ListItemButton';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
 import Toolbar from '@mui/material/Toolbar';
+import { useTheme } from '@mui/material/styles';
 import type {} from '@mui/material/themeCssVarsAugmentation';
-import PersonIcon from '@mui/icons-material/Person';
-import MenuBookIcon from '@mui/icons-material/MenuBook';
+import useMediaQuery from '@mui/material/useMediaQuery';
+import * as React from 'react';
+
+import AccountCircleIcon from '@mui/icons-material/AccountCircle';
 import BarChartIcon from '@mui/icons-material/BarChart';
 import DescriptionIcon from '@mui/icons-material/Description';
 import LayersIcon from '@mui/icons-material/Layers';
-import LogoutOutlinedIcon from '@mui/icons-material/LogoutOutlined';
-import { matchPath, useLocation } from 'react-router-dom';
-import DashboardSidebarContext from '../context/DashboardSidebarContext';
-import { DRAWER_WIDTH, MINI_DRAWER_WIDTH } from '../constants';
-import DashboardSidebarPageItem from './DashboardSidebarPageItem';
-import DashboardSidebarHeaderItem from './DashboardSidebarHeaderItem';
-import DashboardSidebarDividerItem from './DashboardSidebarDividerItem';
-import { getDrawerSxTransitionMixin, getDrawerWidthTransitionMixin } from '../mixins';
+import MenuBookIcon from '@mui/icons-material/MenuBook';
+import PersonIcon from '@mui/icons-material/Person';
+
+import { matchPath, useLocation, useNavigate } from 'react-router-dom';
+
 import { useAuth } from '../../../../context/AuthContext';
+import { DRAWER_WIDTH, MINI_DRAWER_WIDTH } from '../constants';
+import DashboardSidebarContext from '../context/DashboardSidebarContext';
+import { getDrawerSxTransitionMixin, getDrawerWidthTransitionMixin } from '../mixins';
+import DashboardSidebarDividerItem from './DashboardSidebarDividerItem';
+import DashboardSidebarHeaderItem from './DashboardSidebarHeaderItem';
+import DashboardSidebarPageItem from './DashboardSidebarPageItem';
 
 export interface DashboardSidebarProps {
   expanded?: boolean;
@@ -39,6 +44,7 @@ export default function DashboardSidebar({
   container,
 }: DashboardSidebarProps) {
   const theme = useTheme();
+  const navigate = useNavigate();
   const { logout } = useAuth();
 
   const { pathname } = useLocation();
@@ -50,6 +56,10 @@ export default function DashboardSidebar({
 
   const [isFullyExpanded, setIsFullyExpanded] = React.useState(expanded);
   const [isFullyCollapsed, setIsFullyCollapsed] = React.useState(!expanded);
+
+  // Profile menu state
+  const [profileAnchorEl, setProfileAnchorEl] = React.useState<null | HTMLElement>(null);
+  const profileMenuOpen = Boolean(profileAnchorEl);
 
   React.useEffect(() => {
     if (expanded) {
@@ -109,6 +119,28 @@ export default function DashboardSidebar({
       setExpanded(false);
     }
   }, [logout, isOverSmViewport, setExpanded]);
+
+  // Profile menu handlers
+  const handleProfileClick = React.useCallback((event: React.MouseEvent<HTMLElement>) => {
+    setProfileAnchorEl(event.currentTarget);
+  }, []);
+
+  const handleProfileClose = React.useCallback(() => {
+    setProfileAnchorEl(null);
+  }, []);
+
+  const handleChangePassword = React.useCallback(() => {
+    setProfileAnchorEl(null);
+    navigate('/dashboard/change-password');
+    if (!isOverSmViewport) {
+      setExpanded(false);
+    }
+  }, [navigate, isOverSmViewport, setExpanded]);
+
+  const handleLogoutFromMenu = React.useCallback(() => {
+    setProfileAnchorEl(null);
+    handleLogout();
+  }, [handleLogout]);
 
   const hasDrawerTransitions = isOverSmViewport && (!disableCollapsibleSidebar || isOverMdViewport);
 
@@ -217,6 +249,8 @@ export default function DashboardSidebar({
               />
             </List>
           </Box>
+
+          {/* Bottom section */}
           <List
             dense
             sx={{
@@ -225,10 +259,12 @@ export default function DashboardSidebar({
             }}
           >
             <DashboardSidebarDividerItem />
+
+            {/* Profile button */}
             <ListItem disablePadding sx={{ px: 1 }}>
               <ListItemButton
-                onClick={handleLogout}
-                title={mini ? 'Logout' : undefined}
+                onClick={handleProfileClick}
+                title={mini ? 'Profile' : undefined}
                 sx={{
                   height: mini ? 50 : 'auto',
                   justifyContent: mini ? 'center' : 'flex-start',
@@ -240,16 +276,46 @@ export default function DashboardSidebar({
                     justifyContent: 'center',
                   }}
                 >
-                  <LogoutOutlinedIcon fontSize="small" />
+                  <AccountCircleIcon fontSize="small" />
                 </ListItemIcon>
-                {!mini ? <ListItemText primary="Logout" /> : null}
+                {!mini ? <ListItemText primary="Profile" /> : null}
               </ListItemButton>
             </ListItem>
           </List>
+
+          {/* Profile menu popover */}
+          <Menu
+            anchorEl={profileAnchorEl}
+            open={profileMenuOpen}
+            onClose={handleProfileClose}
+            anchorOrigin={{
+              vertical: 'top',
+              horizontal: 'right',
+            }}
+            transformOrigin={{
+              vertical: 'bottom',
+              horizontal: 'left',
+            }}
+          >
+            <MenuItem onClick={handleChangePassword}>Change Password</MenuItem>
+            <MenuItem onClick={handleLogoutFromMenu}>Logout</MenuItem>
+          </Menu>
         </Box>
       </Box>
     ),
-    [mini, hasDrawerTransitions, isFullyExpanded, expandedItemIds, pathname, handleLogout],
+    [
+      mini,
+      hasDrawerTransitions,
+      isFullyExpanded,
+      expandedItemIds,
+      pathname,
+      handleProfileClick,
+      handleProfileClose,
+      profileAnchorEl,
+      profileMenuOpen,
+      handleChangePassword,
+      handleLogoutFromMenu,
+    ],
   );
 
   const getDrawerSharedSx = React.useCallback(
@@ -309,6 +375,7 @@ export default function DashboardSidebar({
       >
         {getDrawerContent('phone')}
       </Drawer>
+
       <Drawer
         variant="permanent"
         sx={{
@@ -322,6 +389,7 @@ export default function DashboardSidebar({
       >
         {getDrawerContent('tablet')}
       </Drawer>
+
       <Drawer
         variant="permanent"
         sx={{


### PR DESCRIPTION
**UI**
Replaced the sidebar logout button with a profile menu in the dashboard sidebar. Includes:
- Change Password
- Logout

**Change Password Page**
- Added a new Change Password page in the dashboard.
- Integrated the page with the existing OpenAPI-backed changePassword endpoint via useAuth().
- Added required current password input to match backend API contract.
- Left security to backend but did add 2 small input checks: min password len of 8 & confirm new passwords match

**Routing** 
- Added /dashboard/change-password route to the dashboard layout

Fixes #12 