### PR TITLE
fix: make author sorting case-insensitive

### DIFF
--- a/backend/src/main/java/edu/duke/bookpublishing/books/BookController.java
+++ b/backend/src/main/java/edu/duke/bookpublishing/books/BookController.java
@@ -63,7 +63,8 @@ public class BookController {
 
     Sort sort =
         sortField != null
-            ? Sort.by(Sort.Direction.fromString(sortDirection), sortField)
+            ? Sort.by(
+                new Sort.Order(Sort.Direction.fromString(sortDirection), sortField).ignoreCase())
             : Sort.unsorted();
 
     if (showAll) {

--- a/backend/src/main/java/edu/duke/bookpublishing/books/BookRepository.java
+++ b/backend/src/main/java/edu/duke/bookpublishing/books/BookRepository.java
@@ -26,7 +26,7 @@ public interface BookRepository extends JpaRepository<Book, Long>, JpaSpecificat
           select distinct b.author
           from Book b
           where lower(b.author) like concat('%', lower(:query), '%')
-          order by b.author asc
+          order by lower(b.author) asc
           """)
   List<String> findDistinctAuthors(@Param("query") String query);
 
@@ -35,7 +35,7 @@ public interface BookRepository extends JpaRepository<Book, Long>, JpaSpecificat
           select distinct b.author
           from Book b
           where lower(b.author) like concat('%', lower(:query), '%')
-          order by b.author asc
+          order by lower(b.author) asc
           """)
   Page<String> findDistinctAuthors(@Param("query") String query, Pageable pageable);
 }

--- a/backend/src/main/java/edu/duke/bookpublishing/sales/SaleController.java
+++ b/backend/src/main/java/edu/duke/bookpublishing/sales/SaleController.java
@@ -60,7 +60,8 @@ public class SaleController {
 
     Sort sort =
         sortField != null
-            ? Sort.by(Sort.Direction.fromString(sortDirection), sortField)
+            ? Sort.by(
+                new Sort.Order(Sort.Direction.fromString(sortDirection), sortField).ignoreCase())
             : Sort.unsorted();
 
     if (showAll) {

--- a/backend/src/main/java/edu/duke/bookpublishing/sales/SaleService.java
+++ b/backend/src/main/java/edu/duke/bookpublishing/sales/SaleService.java
@@ -76,7 +76,7 @@ public class SaleService {
 
     Sort sort =
         Sort.by(
-            Sort.Order.asc("book.author"),
+            Sort.Order.asc("book.author").ignoreCase(),
             Sort.Order.desc("saleYear"),
             Sort.Order.desc("saleMonth"));
 


### PR DESCRIPTION
Summary                                                                                            
                                                                                                     
  - Authors were sorting case-sensitively (all uppercase before all lowercase, e.g. "Zelda" before   
  "alice"). This applies lower() / ignoreCase() across all four backend sort paths: author search  
  autocomplete, book list sorting, sale list sorting, and author payment grouping.                   
                                                                                                     
  Test plan                                                                                          
                                                                                                     
  - Verify author autocomplete dropdown (/api/books/authors) returns names in case-insensitive
  alphabetical order
  - Verify sorting books by author column treats "alice" and "Alice" equivalently
  - Verify author payments view groups authors in case-insensitive order
  - Verify sorting sales by author is case-insensitive