### PR TITLE
fix: resolve internal server error when sorting books and sales

### DIFF
--- a/backend/src/main/java/edu/duke/bookpublishing/books/Book.java
+++ b/backend/src/main/java/edu/duke/bookpublishing/books/Book.java
@@ -3,6 +3,7 @@ package edu.duke.bookpublishing.books;
 import jakarta.persistence.*;
 import java.math.BigDecimal;
 import lombok.*;
+import org.hibernate.annotations.Formula;
 
 @Entity
 @Table(name = "books")
@@ -36,6 +37,9 @@ public class Book {
 
   @Column(name = "royalty_rate", nullable = false, precision = 5, scale = 4)
   private BigDecimal royaltyRate;
+
+  @Formula("(SELECT COALESCE(SUM(s.quantity_sold), 0) FROM sales s WHERE s.book_id = id)")
+  private Long totalSalesToDate;
 
   @PrePersist
   @PreUpdate

--- a/backend/src/main/java/edu/duke/bookpublishing/books/BookController.java
+++ b/backend/src/main/java/edu/duke/bookpublishing/books/BookController.java
@@ -65,7 +65,9 @@ public class BookController {
     if (sortField != null) {
       Sort.Direction dir = Sort.Direction.fromString(sortDirection);
       if ("publicationDate".equals(sortField)) {
-        sort = Sort.by(new Sort.Order(dir, "publicationYear"), new Sort.Order(dir, "publicationMonth"));
+        sort =
+            Sort.by(
+                new Sort.Order(dir, "publicationYear"), new Sort.Order(dir, "publicationMonth"));
       } else {
         sort = Sort.by(new Sort.Order(dir, sortField));
       }

--- a/backend/src/main/java/edu/duke/bookpublishing/books/BookController.java
+++ b/backend/src/main/java/edu/duke/bookpublishing/books/BookController.java
@@ -61,11 +61,17 @@ public class BookController {
       @RequestParam(required = false) String sortField,
       @RequestParam(defaultValue = "asc") String sortDirection) {
 
-    Sort sort =
-        sortField != null
-            ? Sort.by(
-                new Sort.Order(Sort.Direction.fromString(sortDirection), sortField).ignoreCase())
-            : Sort.unsorted();
+    Sort sort;
+    if (sortField != null) {
+      Sort.Direction dir = Sort.Direction.fromString(sortDirection);
+      if ("publicationDate".equals(sortField)) {
+        sort = Sort.by(new Sort.Order(dir, "publicationYear"), new Sort.Order(dir, "publicationMonth"));
+      } else {
+        sort = Sort.by(new Sort.Order(dir, sortField));
+      }
+    } else {
+      sort = Sort.unsorted();
+    }
 
     if (showAll) {
       List<Book> all = bookService.findAll(query, sort);

--- a/backend/src/main/java/edu/duke/bookpublishing/sales/SaleController.java
+++ b/backend/src/main/java/edu/duke/bookpublishing/sales/SaleController.java
@@ -60,8 +60,7 @@ public class SaleController {
 
     Sort sort =
         sortField != null
-            ? Sort.by(
-                new Sort.Order(Sort.Direction.fromString(sortDirection), sortField).ignoreCase())
+            ? Sort.by(new Sort.Order(Sort.Direction.fromString(sortDirection), sortField))
             : Sort.unsorted();
 
     if (showAll) {


### PR DESCRIPTION
## summary

sorting books or sales by any column in ascending or descending order returned a 500 internal server error. this was caused by three distinct issues in the backend sort handling.

## changes

### 1. remove `.ignoreCase()` from sort order construction
the `Sort.Order.ignoreCase()` call in both `BookController` and `SaleController` caused hibernate to wrap every ORDER BY column in `LOWER()`. this works for string columns like `title` and `author`, but fails for non-string columns (`id`, `publicationYear`, `royaltyRate`, etc.) because `LOWER()` cannot be applied to numeric types.

**fix:** removed `.ignoreCase()` from both controllers.

### 2. map `publicationDate` sort field to entity columns
the frontend sends `publicationDate` as the sort field for the publication column, but the `Book` entity stores publication as two separate fields: `publicationYear` and `publicationMonth`. hibernate could not resolve `publicationDate` as a property and threw an error.

**fix:** added a mapping in `BookController` that translates `publicationDate` into a compound sort on `publicationYear` then `publicationMonth`.

### 3. enable database-level sorting for `totalSalesToDate`
`totalSalesToDate` is a computed value (sum of `quantity_sold` from the `sales` table), not a column on the `books` table. sorting by it at the database level — which is required for correct pagination — was not possible.

**fix:** added a hibernate `@Formula` annotation to the `Book` entity:

```java
@Formula("(SELECT COALESCE(SUM(s.quantity_sold), 0) FROM sales s WHERE s.book_id = id)")
private Long totalSalesToDate;
```

`@Formula` is a hibernate annotation that defines a read-only, computed SQL expression on an entity. unlike a real column, the expression is evaluated as an inline subquery every time the entity is loaded. because hibernate includes it in the generated SQL SELECT, it can also be referenced in ORDER BY — which means spring data's `Sort.by("totalSalesToDate")` works natively with pagination.

## files changed

- `Book.java` — added `@Formula` field for `totalSalesToDate`
- `BookController.java` — removed `.ignoreCase()`, added `publicationDate` sort mapping
- `SaleController.java` — removed `.ignoreCase()`

## test plan

- [ ] sort books by each column (title, author, isbn, publication, royalty, total sales) in both asc and desc
- [ ] verify pagination still works correctly when sorting
- [ ] sort sales by each column in both asc and desc
- [ ] verify no 500 errors in backend logs