### PR TITLE
fix: resolve high-priority performance, bug, and duplication issues

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -22,5 +22,6 @@
   "[json]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
-  "java.compile.nullAnalysis.mode": "disabled"
+  "java.compile.nullAnalysis.mode": "disabled",
+  "java.configuration.updateBuildConfiguration": "interactive"
 }

--- a/backend/src/main/java/edu/duke/bookpublishing/books/Book.java
+++ b/backend/src/main/java/edu/duke/bookpublishing/books/Book.java
@@ -1,5 +1,6 @@
 package edu.duke.bookpublishing.books;
 
+import edu.duke.bookpublishing.common.StringUtils;
 import jakarta.persistence.*;
 import java.math.BigDecimal;
 import lombok.*;
@@ -47,10 +48,7 @@ public class Book {
     if (title != null) {
       title = title.trim();
     }
-    // Whitespace normalization for author (def 17)
-    if (author != null) {
-      author = String.join(" ", author.trim().split("\\s+"));
-    }
+    author = StringUtils.normalizeWhitespace(author);
     if (isbn13 != null) {
       isbn13 = isbn13.replaceAll("-", "");
     }

--- a/backend/src/main/java/edu/duke/bookpublishing/books/BookController.java
+++ b/backend/src/main/java/edu/duke/bookpublishing/books/BookController.java
@@ -78,13 +78,12 @@ public class BookController {
     if (showAll) {
       List<Book> all = bookService.findAll(query, sort);
       return PagedResponse.unpaged(
-          all, book -> BookResponse.from(book, saleService.getBookTotalSales(book.getId())));
+          all, book -> BookResponse.from(book, book.getTotalSalesToDate()));
     }
 
     Pageable pageable = PageRequest.of(page, size, sort);
     Page<Book> books = bookService.findAll(pageable, query);
-    return PagedResponse.paged(
-        books, book -> BookResponse.from(book, saleService.getBookTotalSales(book.getId())));
+    return PagedResponse.paged(books, book -> BookResponse.from(book, book.getTotalSalesToDate()));
   }
 
   @Operation(operationId = "searchAuthors", summary = "Search distinct author names")

--- a/backend/src/main/java/edu/duke/bookpublishing/books/BookService.java
+++ b/backend/src/main/java/edu/duke/bookpublishing/books/BookService.java
@@ -61,5 +61,4 @@ public class BookService {
   public void deleteById(Long id) {
     bookRepository.deleteById(id);
   }
-
 }

--- a/backend/src/main/java/edu/duke/bookpublishing/books/BookService.java
+++ b/backend/src/main/java/edu/duke/bookpublishing/books/BookService.java
@@ -1,5 +1,6 @@
 package edu.duke.bookpublishing.books;
 
+import edu.duke.bookpublishing.common.StringUtils;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -34,7 +35,7 @@ public class BookService {
 
   // Distinct author search for autocomplete.
   public List<String> findDistinctAuthors(String query) {
-    String normalizedQuery = normalizeWhitespace(query);
+    String normalizedQuery = StringUtils.normalizeWhitespace(query);
     if (normalizedQuery == null || normalizedQuery.isBlank()) {
       return List.of();
     }
@@ -42,7 +43,7 @@ public class BookService {
   }
 
   public Page<String> findDistinctAuthors(String query, Pageable pageable) {
-    String normalizedQuery = normalizeWhitespace(query);
+    String normalizedQuery = StringUtils.normalizeWhitespace(query);
     if (normalizedQuery == null || normalizedQuery.isBlank()) {
       return Page.empty(pageable);
     }
@@ -61,11 +62,4 @@ public class BookService {
     bookRepository.deleteById(id);
   }
 
-  // Mirrors Book.normalizeFields() whitespace normalization (def 17).
-  private String normalizeWhitespace(String value) {
-    if (value == null) {
-      return null;
-    }
-    return String.join(" ", value.trim().split("\\s+"));
-  }
 }

--- a/backend/src/main/java/edu/duke/bookpublishing/common/StringUtils.java
+++ b/backend/src/main/java/edu/duke/bookpublishing/common/StringUtils.java
@@ -1,0 +1,17 @@
+package edu.duke.bookpublishing.common;
+
+public final class StringUtils {
+
+  private StringUtils() {}
+
+  /**
+   * Trims leading/trailing whitespace and collapses internal whitespace runs to a single space.
+   * Returns null if input is null.
+   */
+  public static String normalizeWhitespace(String value) {
+    if (value == null) {
+      return null;
+    }
+    return String.join(" ", value.trim().split("\\s+"));
+  }
+}

--- a/backend/src/main/java/edu/duke/bookpublishing/config/DataSeeder.java
+++ b/backend/src/main/java/edu/duke/bookpublishing/config/DataSeeder.java
@@ -56,7 +56,6 @@ public class DataSeeder implements CommandLineRunner {
         String[] dateParts = publicationDate.split("/");
         int month = Integer.parseInt(dateParts[0]);
         int year = Integer.parseInt(dateParts[1]);
-
         Book book =
             Book.builder()
                 .title(title)
@@ -100,7 +99,6 @@ public class DataSeeder implements CommandLineRunner {
         String[] dateParts = recordDate.split("/");
         int month = Integer.parseInt(dateParts[0]);
         int year = Integer.parseInt(dateParts[1]);
-
         Sale sale =
             Sale.builder()
                 .book(book)

--- a/backend/src/main/java/edu/duke/bookpublishing/sales/SaleService.java
+++ b/backend/src/main/java/edu/duke/bookpublishing/sales/SaleService.java
@@ -2,6 +2,7 @@ package edu.duke.bookpublishing.sales;
 
 import edu.duke.bookpublishing.books.Book;
 import edu.duke.bookpublishing.books.BookRepository;
+import edu.duke.bookpublishing.common.StringUtils;
 import edu.duke.bookpublishing.exception.custom.NotFoundException;
 import edu.duke.bookpublishing.sales.dto.AuthorPaymentGroupResponse;
 import edu.duke.bookpublishing.sales.dto.AuthorPaymentSaleResponse;
@@ -190,7 +191,7 @@ public class SaleService {
    */
   @Transactional
   public int markAllPaidByAuthor(String author) {
-    String normalizedAuthor = normalizeWhitespace(author);
+    String normalizedAuthor = StringUtils.normalizeWhitespace(author);
     return saleRepository.markAllPaidByAuthor(normalizedAuthor);
   }
 
@@ -226,11 +227,4 @@ public class SaleService {
     return publisherRevenue.multiply(bookRoyaltyRate).setScale(2, RoundingMode.HALF_UP);
   }
 
-  // Mirrors Book.normalizeFields() whitespace normalization (def 17).
-  private String normalizeWhitespace(String value) {
-    if (value == null) {
-      return null;
-    }
-    return String.join(" ", value.trim().split("\\s+"));
-  }
 }

--- a/backend/src/main/java/edu/duke/bookpublishing/sales/SaleService.java
+++ b/backend/src/main/java/edu/duke/bookpublishing/sales/SaleService.java
@@ -226,5 +226,4 @@ public class SaleService {
     }
     return publisherRevenue.multiply(bookRoyaltyRate).setScale(2, RoundingMode.HALF_UP);
   }
-
 }

--- a/backend/src/main/java/edu/duke/bookpublishing/sales/dto/SaleResponse.java
+++ b/backend/src/main/java/edu/duke/bookpublishing/sales/dto/SaleResponse.java
@@ -13,6 +13,8 @@ import java.math.BigDecimal;
 public record SaleResponse(
     @Schema(description = "Unique sale identifier id") Long id,
     @Schema(description = "Unique identifier for the sold book") Long bookId,
+    @Schema(description = "Title of the sold book") String bookTitle,
+    @Schema(description = "Author of the sold book") String bookAuthor,
     @Schema(description = "Month of the sale") Integer saleMonth,
     @Schema(description = "Year of the sale") Integer saleYear,
     @Schema(description = "Quantity of books sold") Integer quantitySold,
@@ -25,6 +27,8 @@ public record SaleResponse(
     return new SaleResponse(
         sale.getId(),
         sale.getBook().getId(),
+        sale.getBook().getTitle(),
+        sale.getBook().getAuthor(),
         sale.getSaleMonth(),
         sale.getSaleYear(),
         sale.getQuantitySold(),

--- a/backend/src/test/java/edu/duke/bookpublishing/common/StringUtilsTest.java
+++ b/backend/src/test/java/edu/duke/bookpublishing/common/StringUtilsTest.java
@@ -1,0 +1,38 @@
+package edu.duke.bookpublishing.common;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class StringUtilsTest {
+
+  @Test
+  void nullInput_returnsNull() {
+    assertNull(StringUtils.normalizeWhitespace(null));
+  }
+
+  @Test
+  void emptyString_returnsEmpty() {
+    assertEquals("", StringUtils.normalizeWhitespace(""));
+  }
+
+  @Test
+  void trimsLeadingAndTrailingWhitespace() {
+    assertEquals("hello", StringUtils.normalizeWhitespace("  hello  "));
+  }
+
+  @Test
+  void collapsesInternalWhitespace() {
+    assertEquals("John Robert Smith", StringUtils.normalizeWhitespace("John   Robert   Smith"));
+  }
+
+  @Test
+  void handlesTabs() {
+    assertEquals("a b c", StringUtils.normalizeWhitespace("a\tb\t\tc"));
+  }
+
+  @Test
+  void noOpForAlreadyNormalized() {
+    assertEquals("already normal", StringUtils.normalizeWhitespace("already normal"));
+  }
+}

--- a/frontend/src/api/generated/models/SaleResponse.ts
+++ b/frontend/src/api/generated/models/SaleResponse.ts
@@ -15,6 +15,14 @@ export type SaleResponse = {
      */
     bookId?: number;
     /**
+     * Title of the sold book
+     */
+    bookTitle?: string;
+    /**
+     * Author of the sold book
+     */
+    bookAuthor?: string;
+    /**
      * Month of the sale
      */
     saleMonth?: number;

--- a/frontend/src/constants/months.ts
+++ b/frontend/src/constants/months.ts
@@ -1,0 +1,29 @@
+export const MONTH_NAMES = [
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December',
+] as const;
+
+export const MONTH_NAMES_SHORT = [
+  'Jan',
+  'Feb',
+  'Mar',
+  'Apr',
+  'May',
+  'Jun',
+  'Jul',
+  'Aug',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dec',
+] as const;

--- a/frontend/src/pages/dashboard/crud-dashboard/components/AuthorPayments.tsx
+++ b/frontend/src/pages/dashboard/crud-dashboard/components/AuthorPayments.tsx
@@ -52,21 +52,7 @@ import {
   type PagedResponseString,
 } from '../../../../api';
 import useNotifications from '../hooks/useNotifications/useNotifications';
-
-const MONTH_NAMES = [
-  'Jan',
-  'Feb',
-  'Mar',
-  'Apr',
-  'May',
-  'Jun',
-  'Jul',
-  'Aug',
-  'Sep',
-  'Oct',
-  'Nov',
-  'Dec',
-];
+import { MONTH_NAMES_SHORT as MONTH_NAMES } from '../../../../constants/months';
 const INITIAL_PAGE_SIZE = 25;
 const PAGE_SIZE_OPTIONS = [10, 25, 50, 100];
 const ALL_SENTINEL = -1;

--- a/frontend/src/pages/dashboard/crud-dashboard/components/BookEdit.tsx
+++ b/frontend/src/pages/dashboard/crud-dashboard/components/BookEdit.tsx
@@ -175,10 +175,10 @@ export default function BookEdit() {
   }
   return (
     <PageContainer
-      title={`${book!.title}`}
+      title={book?.title ?? 'Edit Book'}
       breadcrumbs={[
         { title: 'Books', path: '/dashboard/books' },
-        { title: truncate(book!.title), path: `/dashboard/books/${bookId}` },
+        { title: truncate(book?.title) || 'Book', path: `/dashboard/books/${bookId}` },
         { title: 'Edit' },
       ]}
     >

--- a/frontend/src/pages/dashboard/crud-dashboard/components/BookForm.tsx
+++ b/frontend/src/pages/dashboard/crud-dashboard/components/BookForm.tsx
@@ -9,21 +9,7 @@ import MenuItem from '@mui/material/MenuItem';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import { useNavigate } from 'react-router-dom';
 import type { Book } from '../data/books';
-
-const MONTH_NAMES = [
-  'January',
-  'February',
-  'March',
-  'April',
-  'May',
-  'June',
-  'July',
-  'August',
-  'September',
-  'October',
-  'November',
-  'December',
-];
+import { MONTH_NAMES } from '../../../../constants/months';
 
 export interface BookFormState {
   values: Partial<Omit<Book, 'id' | 'totalSalesToDate'>>;

--- a/frontend/src/pages/dashboard/crud-dashboard/components/BookList.tsx
+++ b/frontend/src/pages/dashboard/crud-dashboard/components/BookList.tsx
@@ -25,21 +25,7 @@ import { deleteOne as deleteBook, getMany as getBooks, type Book } from '../data
 import { useDialogs } from '../hooks/useDialogs/useDialogs';
 import useNotifications from '../hooks/useNotifications/useNotifications';
 import PageContainer from './PageContainer';
-
-const MONTH_NAMES = [
-  'Jan',
-  'Feb',
-  'Mar',
-  'Apr',
-  'May',
-  'Jun',
-  'Jul',
-  'Aug',
-  'Sep',
-  'Oct',
-  'Nov',
-  'Dec',
-];
+import { MONTH_NAMES_SHORT as MONTH_NAMES } from '../../../../constants/months';
 
 const INITIAL_PAGE_SIZE = 25;
 

--- a/frontend/src/pages/dashboard/crud-dashboard/components/BookSalesList.tsx
+++ b/frontend/src/pages/dashboard/crud-dashboard/components/BookSalesList.tsx
@@ -26,21 +26,7 @@ import { useNavigate } from 'react-router-dom';
 import * as salesData from '../data/sales';
 import { useDialogs } from '../hooks/useDialogs/useDialogs';
 import useNotifications from '../hooks/useNotifications/useNotifications';
-
-const MONTH_NAMES = [
-  'January',
-  'February',
-  'March',
-  'April',
-  'May',
-  'June',
-  'July',
-  'August',
-  'September',
-  'October',
-  'November',
-  'December',
-];
+import { MONTH_NAMES } from '../../../../constants/months';
 
 type Props = {
   bookId?: number;

--- a/frontend/src/pages/dashboard/crud-dashboard/components/BookShow.tsx
+++ b/frontend/src/pages/dashboard/crud-dashboard/components/BookShow.tsx
@@ -20,21 +20,7 @@ import * as salesData from '../data/sales';
 import { useDialogs } from '../hooks/useDialogs/useDialogs';
 import useNotifications from '../hooks/useNotifications/useNotifications';
 import PageContainer from './PageContainer';
-
-const MONTH_NAMES = [
-  'January',
-  'February',
-  'March',
-  'April',
-  'May',
-  'June',
-  'July',
-  'August',
-  'September',
-  'October',
-  'November',
-  'December',
-];
+import { MONTH_NAMES } from '../../../../constants/months';
 
 export default function BookShow() {
   const { bookId } = useParams<{ bookId?: string }>();

--- a/frontend/src/pages/dashboard/crud-dashboard/components/SaleEdit.tsx
+++ b/frontend/src/pages/dashboard/crud-dashboard/components/SaleEdit.tsx
@@ -21,21 +21,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { BooksService, SalesService, type BookResponse, type SaleResponse } from '../../../../api';
 import useNotifications from '../hooks/useNotifications/useNotifications';
 import PageContainer from './PageContainer';
-
-const MONTH_NAMES = [
-  'January',
-  'February',
-  'March',
-  'April',
-  'May',
-  'June',
-  'July',
-  'August',
-  'September',
-  'October',
-  'November',
-  'December',
-];
+import { MONTH_NAMES } from '../../../../constants/months';
 
 export default function SaleEdit() {
   const { saleId } = useParams();
@@ -102,8 +88,11 @@ export default function SaleEdit() {
       const book = (booksResponse.content ?? []).find((b) => b.id === saleData.bookId);
       setSelectedBook(book ?? null);
 
-      // On load, do not mark as overridden or edited
-      setIsRoyaltyOverridden(false);
+      // Detect if the saved royalty was overridden from the computed default
+      const savedRoyalty = saleData.authorRoyalty ?? 0;
+      const expectedRoyalty = (saleData.publisherRevenue ?? 0) * (book?.royaltyRate ?? 0);
+      const wasOverridden = Math.abs(savedRoyalty - parseFloat(expectedRoyalty.toFixed(2))) > 0.001;
+      setIsRoyaltyOverridden(wasOverridden);
       setHasRoyaltyBeenEdited(false);
     } catch (loadError) {
       setError(loadError as Error);

--- a/frontend/src/pages/dashboard/crud-dashboard/components/SaleList.tsx
+++ b/frontend/src/pages/dashboard/crud-dashboard/components/SaleList.tsx
@@ -26,21 +26,7 @@ import * as React from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { type SaleResponse, SalesService } from '../../../../api';
 import PageContainer from './PageContainer';
-
-const MONTH_NAMES = [
-  'Jan',
-  'Feb',
-  'Mar',
-  'Apr',
-  'May',
-  'Jun',
-  'Jul',
-  'Aug',
-  'Sep',
-  'Oct',
-  'Nov',
-  'Dec',
-];
+import { MONTH_NAMES_SHORT as MONTH_NAMES } from '../../../../constants/months';
 const INITIAL_PAGE_SIZE = 25;
 
 export default function SaleList() {

--- a/frontend/src/pages/dashboard/crud-dashboard/components/SaleList.tsx
+++ b/frontend/src/pages/dashboard/crud-dashboard/components/SaleList.tsx
@@ -24,7 +24,7 @@ import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import dayjs, { type Dayjs } from 'dayjs';
 import * as React from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import { type BookResponse, BooksService, type SaleResponse, SalesService } from '../../../../api';
+import { type SaleResponse, SalesService } from '../../../../api';
 import PageContainer from './PageContainer';
 
 const MONTH_NAMES = [
@@ -61,8 +61,6 @@ export default function SaleList() {
   const [totalCount, setTotalCount] = React.useState(0);
   const [isLoading, setIsLoading] = React.useState(true);
   const [error, setError] = React.useState<Error | null>(null);
-  const [booksMap, setBooksMap] = React.useState<Map<number, BookResponse>>(new Map());
-
   const [startDate, setStartDate] = React.useState<Dayjs | null>(null);
   const [endDate, setEndDate] = React.useState<Dayjs | null>(null);
 
@@ -97,26 +95,6 @@ export default function SaleList() {
 
       setSales(response.content ?? []);
       setTotalCount(response.totalElements ?? 0);
-
-      // Fetch book details for all sales records
-      const uniqueBookIds = Array.from(
-        new Set((response.content ?? []).map((s) => s.bookId).filter(Boolean)),
-      ) as number[];
-
-      if (uniqueBookIds.length > 0) {
-        const bookPromises = uniqueBookIds.map((bookId) =>
-          BooksService.getBookById(bookId).catch(() => null),
-        );
-        const books = await Promise.all(bookPromises);
-
-        const newBooksMap = new Map<number, BookResponse>();
-        books.forEach((book) => {
-          if (book && book.id) newBooksMap.set(book.id, book);
-        });
-        setBooksMap(newBooksMap);
-      } else {
-        setBooksMap(new Map());
-      }
     } catch (loadError) {
       setError(loadError as Error);
     } finally {
@@ -175,14 +153,9 @@ export default function SaleList() {
         field: 'bookTitle',
         headerName: 'Book Title',
         width: 200,
-        valueGetter: (_value, row) => {
-          const book = booksMap.get(row.bookId ?? 0);
-          return book?.title ?? `Book ${row.bookId}`;
-        },
         renderCell: (params) => {
           const bookId = params.row.bookId;
-          const book = booksMap.get(bookId ?? 0);
-          const title = book?.title ?? `Book ${bookId}`;
+          const title = params.row.bookTitle ?? `Book ${bookId}`;
 
           return (
             <Link
@@ -212,10 +185,6 @@ export default function SaleList() {
         field: 'bookAuthor',
         headerName: 'Author',
         width: 180,
-        valueGetter: (_value, row) => {
-          const book = booksMap.get(row.bookId ?? 0);
-          return book?.author ?? `Author ${row.bookId}`;
-        },
       },
       {
         field: 'saleYear',
@@ -265,7 +234,7 @@ export default function SaleList() {
         },
       },
     ],
-    [booksMap],
+    [],
   );
 
   const pageTitle = 'Sales Records';

--- a/frontend/src/pages/dashboard/crud-dashboard/components/SaleShow.tsx
+++ b/frontend/src/pages/dashboard/crud-dashboard/components/SaleShow.tsx
@@ -19,21 +19,7 @@ import { useDialogs } from '../hooks/useDialogs/useDialogs';
 import useNotifications from '../hooks/useNotifications/useNotifications';
 import { SalesService, BooksService, type SaleResponse, type BookResponse } from '../../../../api';
 import PageContainer from './PageContainer';
-
-const MONTH_NAMES = [
-  'January',
-  'February',
-  'March',
-  'April',
-  'May',
-  'June',
-  'July',
-  'August',
-  'September',
-  'October',
-  'November',
-  'December',
-];
+import { MONTH_NAMES } from '../../../../constants/months';
 
 export default function SaleShow() {
   const { saleId } = useParams();


### PR DESCRIPTION
## Summary

Addresses all 6 HIGH priority items from the TODO list:

**Performance (prior commit):**
- Fix N+1 query in backend book listing — use existing `@Formula` on the Book entity instead of per-book `getBookTotalSales()` calls
- Fix N+1 book fetching in frontend SaleList — batch book data via the sale response instead of individual `getBookById()` calls

**Bugs:**
- Fix `book!.title` non-null assertion crash in BookEdit breadcrumbs — use optional chaining with fallback strings so navigating to a nonexistent book ID doesn't throw
- Fix SaleEdit royalty override false positive — on load, compare saved royalty against computed default (with epsilon tolerance for float precision) instead of unconditionally resetting `isRoyaltyOverridden` to false. Previously, editing a sale with a legitimately overridden royalty would lose the override indicator

**Code duplication:**
- Extract `MONTH_NAMES` (full) and `MONTH_NAMES_SHORT` (abbreviated) to `frontend/src/constants/months.ts`, replacing 8 duplicate array definitions across component files
- Extract `normalizeWhitespace` to shared `StringUtils` utility in backend, removing identical private methods from `BookService`, `SaleService`, and inline logic from `Book.normalizeFields()`

## Test plan

- [x] `npx tsc --noEmit` — no type errors
- [x] `./gradlew test` — all tests pass including new `StringUtilsTest`
- [x] Verify abbreviated months render in BookList, SaleList, AuthorPayments
- [x] Verify full months render in BookForm, BookShow, SaleEdit, SaleShow, BookSalesList
- [x] Navigate to `/dashboard/books/99999/edit` — shows "Edit Book" fallback, no crash
- [x] Edit a sale with overridden royalty — yellow indicator shows on load