### PR TITLE
feat: cover image backend with upload, thumbnails, and openlibrary import

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'com.auth0:java-jwt:4.4.0'
     implementation 'com.opencsv:opencsv:5.9'
+    implementation 'net.coobird:thumbnailator:0.4.20'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/backend/src/main/java/edu/duke/bookpublishing/books/Book.java
+++ b/backend/src/main/java/edu/duke/bookpublishing/books/Book.java
@@ -1,11 +1,14 @@
 package edu.duke.bookpublishing.books;
 
 import edu.duke.bookpublishing.common.StringUtils;
+import jakarta.persistence.Basic;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
@@ -81,8 +84,18 @@ public class Book {
   @Column(name = "print_cost", nullable = false, precision = 19, scale = 2)
   private BigDecimal printCost;
 
-  @Column(name = "cover_image", nullable = true)
-  private String coverImage;
+  @Lob
+  @Column(name = "cover_image")
+  @Basic(fetch = FetchType.LAZY)
+  private byte[] coverImage;
+
+  @Lob
+  @Column(name = "cover_thumbnail")
+  @Basic(fetch = FetchType.LAZY)
+  private byte[] coverThumbnail;
+
+  @Column(name = "cover_content_type")
+  private String coverContentType;
 
   @Formula("(SELECT COALESCE(SUM(s.quantity_sold), 0) FROM sales s WHERE s.book_id = id)")
   private Long totalSalesToDate;

--- a/backend/src/main/java/edu/duke/bookpublishing/books/BookController.java
+++ b/backend/src/main/java/edu/duke/bookpublishing/books/BookController.java
@@ -176,7 +176,6 @@ public class BookController {
             .seriesPosition(request.seriesPosition())
             .coverPrice(request.coverPrice())
             .printCost(request.printCost())
-            .coverImage(request.coverImage())
             .build();
     return BookResponse.from(bookService.save(book));
   }
@@ -209,7 +208,6 @@ public class BookController {
     book.setSeriesPosition(request.seriesPosition());
     book.setCoverPrice(request.coverPrice());
     book.setPrintCost(request.printCost());
-    book.setCoverImage(request.coverImage());
 
     return BookResponse.from(bookService.save(book));
   }

--- a/backend/src/main/java/edu/duke/bookpublishing/books/cover/CoverController.java
+++ b/backend/src/main/java/edu/duke/bookpublishing/books/cover/CoverController.java
@@ -1,0 +1,132 @@
+package edu.duke.bookpublishing.books.cover;
+
+import edu.duke.bookpublishing.books.Book;
+import edu.duke.bookpublishing.books.BookService;
+import edu.duke.bookpublishing.books.lookup.OpenLibraryClient;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.server.ResponseStatusException;
+
+@RestController
+@RequestMapping("/api/books/{bookId}/cover")
+@RequiredArgsConstructor
+@Tag(name = "Book Covers", description = "Cover image management endpoints")
+public class CoverController {
+
+  private final BookService bookService;
+  private final CoverService coverService;
+  private final OpenLibraryClient openLibraryClient;
+
+  @Operation(operationId = "uploadCover", summary = "Upload or replace a book cover image")
+  @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+  public ResponseEntity<Map<String, String>> uploadCover(
+      @PathVariable Long bookId, @RequestParam("file") MultipartFile file) {
+    Book book = findBookOrThrow(bookId);
+
+    try {
+      coverService.processAndStore(book, file);
+    } catch (IllegalArgumentException e) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getMessage(), e);
+    }
+
+    bookService.save(book);
+    return ResponseEntity.ok(Map.of("message", "Cover uploaded successfully"));
+  }
+
+  @Operation(operationId = "getCover", summary = "Get the full-size cover image")
+  @GetMapping
+  public ResponseEntity<byte[]> getCover(@PathVariable Long bookId) {
+    Book book = findBookOrThrow(bookId);
+
+    if (book.getCoverImage() == null) {
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND, "No cover image");
+    }
+
+    return buildImageResponse(book.getCoverImage(), book.getCoverContentType());
+  }
+
+  @Operation(operationId = "getCoverThumbnail", summary = "Get the cover thumbnail")
+  @GetMapping("/thumbnail")
+  public ResponseEntity<byte[]> getCoverThumbnail(@PathVariable Long bookId) {
+    Book book = findBookOrThrow(bookId);
+
+    if (book.getCoverThumbnail() == null) {
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND, "No cover image");
+    }
+
+    return buildImageResponse(book.getCoverThumbnail(), book.getCoverContentType());
+  }
+
+  @Operation(operationId = "deleteCover", summary = "Remove a book cover image")
+  @DeleteMapping
+  public ResponseEntity<Void> deleteCover(@PathVariable Long bookId) {
+    Book book = findBookOrThrow(bookId);
+
+    coverService.removeCover(book);
+    bookService.save(book);
+
+    return ResponseEntity.noContent().build();
+  }
+
+  @Operation(
+      operationId = "importCover",
+      summary = "Import cover from OpenLibrary using the book's ISBN")
+  @PostMapping("/import")
+  public ResponseEntity<Map<String, String>> importCover(@PathVariable Long bookId) {
+    Book book = findBookOrThrow(bookId);
+
+    String isbn = book.getIsbn13() != null ? book.getIsbn13() : book.getIsbn10();
+    if (isbn == null) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Book has no ISBN");
+    }
+
+    byte[] imageBytes;
+    String contentType;
+    try {
+      OpenLibraryClient.CoverDownloadResult result = openLibraryClient.downloadCoverByIsbn(isbn);
+      imageBytes = result.data();
+      contentType = result.contentType();
+    } catch (Exception e) {
+      throw new ResponseStatusException(
+          HttpStatus.BAD_GATEWAY, "Failed to download cover from OpenLibrary", e);
+    }
+
+    try {
+      coverService.processAndStore(book, imageBytes, contentType);
+    } catch (IllegalArgumentException e) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getMessage(), e);
+    }
+
+    bookService.save(book);
+    return ResponseEntity.ok(Map.of("message", "Cover imported successfully"));
+  }
+
+  private Book findBookOrThrow(Long bookId) {
+    return bookService
+        .findById(bookId)
+        .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Book not found"));
+  }
+
+  private ResponseEntity<byte[]> buildImageResponse(byte[] imageData, String contentType) {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.parseMediaType(contentType));
+    headers.set("X-Content-Type-Options", "nosniff");
+    headers.set("Content-Disposition", "inline");
+    headers.setContentLength(imageData.length);
+    return new ResponseEntity<>(imageData, headers, HttpStatus.OK);
+  }
+}

--- a/backend/src/main/java/edu/duke/bookpublishing/books/cover/CoverService.java
+++ b/backend/src/main/java/edu/duke/bookpublishing/books/cover/CoverService.java
@@ -1,0 +1,110 @@
+package edu.duke.bookpublishing.books.cover;
+
+import edu.duke.bookpublishing.books.Book;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Set;
+import javax.imageio.ImageIO;
+import net.coobird.thumbnailator.Thumbnails;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+public class CoverService {
+
+  private static final Logger logger = LoggerFactory.getLogger(CoverService.class);
+
+  private static final Set<String> ALLOWED_CONTENT_TYPES =
+      Set.of("image/jpeg", "image/png", "image/gif", "image/webp");
+
+  @Value("${app.covers.thumbnail-width:200}")
+  private int thumbnailWidth;
+
+  @Value("${app.covers.thumbnail-height:300}")
+  private int thumbnailHeight;
+
+  public void processAndStore(Book book, MultipartFile file) {
+    if (file.isEmpty()) {
+      throw new IllegalArgumentException("File is empty");
+    }
+
+    String contentType = file.getContentType();
+    if (contentType == null || !ALLOWED_CONTENT_TYPES.contains(contentType)) {
+      throw new IllegalArgumentException("Unsupported image type. Allowed: JPEG, PNG, GIF, WebP");
+    }
+
+    byte[] imageBytes;
+    try {
+      imageBytes = file.getBytes();
+    } catch (IOException e) {
+      throw new IllegalStateException("Failed to read uploaded file", e);
+    }
+
+    validateImageBytes(imageBytes);
+
+    byte[] thumbnail = generateThumbnail(imageBytes, contentType);
+
+    book.setCoverImage(imageBytes);
+    book.setCoverThumbnail(thumbnail);
+    book.setCoverContentType(contentType);
+  }
+
+  public void processAndStore(Book book, byte[] imageBytes, String contentType) {
+    if (imageBytes == null || imageBytes.length == 0) {
+      throw new IllegalArgumentException("Image data is empty");
+    }
+
+    if (contentType == null || !ALLOWED_CONTENT_TYPES.contains(contentType)) {
+      throw new IllegalArgumentException("Unsupported image type. Allowed: JPEG, PNG, GIF, WebP");
+    }
+
+    validateImageBytes(imageBytes);
+
+    byte[] thumbnail = generateThumbnail(imageBytes, contentType);
+
+    book.setCoverImage(imageBytes);
+    book.setCoverThumbnail(thumbnail);
+    book.setCoverContentType(contentType);
+  }
+
+  public void removeCover(Book book) {
+    book.setCoverImage(null);
+    book.setCoverThumbnail(null);
+    book.setCoverContentType(null);
+  }
+
+  private void validateImageBytes(byte[] imageBytes) {
+    try {
+      BufferedImage image = ImageIO.read(new ByteArrayInputStream(imageBytes));
+      if (image == null) {
+        throw new IllegalArgumentException("File is not a valid image");
+      }
+    } catch (IOException e) {
+      throw new IllegalArgumentException("File is not a valid image", e);
+    }
+  }
+
+  private byte[] generateThumbnail(byte[] original, String contentType) {
+    try {
+      String formatName = contentType.substring(contentType.indexOf('/') + 1);
+      if ("webp".equals(formatName)) {
+        formatName = "png";
+      }
+
+      ByteArrayOutputStream out = new ByteArrayOutputStream();
+      Thumbnails.of(new ByteArrayInputStream(original))
+          .size(thumbnailWidth, thumbnailHeight)
+          .outputFormat(formatName)
+          .toOutputStream(out);
+      return out.toByteArray();
+    } catch (IOException e) {
+      logger.warn("Failed to generate thumbnail, using original image", e);
+      return original;
+    }
+  }
+}

--- a/backend/src/main/java/edu/duke/bookpublishing/books/dto/BookDetailResponse.java
+++ b/backend/src/main/java/edu/duke/bookpublishing/books/dto/BookDetailResponse.java
@@ -21,13 +21,13 @@ public record BookDetailResponse(
     @Schema(description = "Series position") Integer seriesPosition,
     @Schema(description = "Cover price (USD)") BigDecimal coverPrice,
     @Schema(description = "Print cost (USD)") BigDecimal printCost,
-    @Schema(description = "Cover image URL") String coverImage,
     @Schema(description = "Total sales quantity to date") Long totalSalesToDate,
     @Schema(description = "Total publisher revenue earned from this book") BigDecimal revenue,
     @Schema(description = "Total author unpaid royalty from the book") BigDecimal unpaidRoyalty,
     @Schema(description = "Total author paid royalty from the book") BigDecimal paidRoyalty,
     @Schema(description = "Total royalty earned by the author (both paid and unpaid)")
-        BigDecimal totalRoyalty) {
+        BigDecimal totalRoyalty,
+    @Schema(description = "Whether this book has a cover image") Boolean hasCover) {
 
   public static BookDetailResponse from(Book book, BookFinancialSummary financialSummary) {
     return new BookDetailResponse(
@@ -44,11 +44,11 @@ public record BookDetailResponse(
         book.getSeriesPosition(),
         book.getCoverPrice(),
         book.getPrintCost(),
-        book.getCoverImage(),
         financialSummary.totalUnitsSold(),
         financialSummary.revenue(),
         financialSummary.unpaidRoyalty(),
         financialSummary.paidRoyalty(),
-        financialSummary.totalRoyalty());
+        financialSummary.totalRoyalty(),
+        book.getCoverImage() != null);
   }
 }

--- a/backend/src/main/java/edu/duke/bookpublishing/books/dto/BookRequest.java
+++ b/backend/src/main/java/edu/duke/bookpublishing/books/dto/BookRequest.java
@@ -58,9 +58,7 @@ public record BookRequest(
     @Schema(description = "Print cost (USD)", example = "4.50")
         @NotNull(message = "Print cost is required")
         @DecimalMin("0.00")
-        BigDecimal printCost,
-    @Schema(description = "Cover image file destination", example = "home/images/img1.png")
-        String coverImage) {
+        BigDecimal printCost) {
 
   @AssertTrue(message = "Cover price must be greater than print cost")
   public boolean isCoverPriceGreaterThanPrintCost() {

--- a/backend/src/main/java/edu/duke/bookpublishing/books/dto/BookResponse.java
+++ b/backend/src/main/java/edu/duke/bookpublishing/books/dto/BookResponse.java
@@ -20,8 +20,8 @@ public record BookResponse(
     @Schema(description = "Series position") Integer seriesPosition,
     @Schema(description = "Cover price (USD)") BigDecimal coverPrice,
     @Schema(description = "Print cost (USD)") BigDecimal printCost,
-    @Schema(description = "Cover image URL") String coverImage,
-    @Schema(description = "Total sales quantity to date") Long totalSalesToDate) {
+    @Schema(description = "Total sales quantity to date") Long totalSalesToDate,
+    @Schema(description = "Whether this book has a cover image") Boolean hasCover) {
 
   public static BookResponse from(Book book) {
     return from(book, 0L);
@@ -42,7 +42,7 @@ public record BookResponse(
         book.getSeriesPosition(),
         book.getCoverPrice(),
         book.getPrintCost(),
-        book.getCoverImage(),
-        totalSaleToDate);
+        totalSaleToDate,
+        book.getCoverImage() != null);
   }
 }

--- a/backend/src/main/java/edu/duke/bookpublishing/books/lookup/BookLookupService.java
+++ b/backend/src/main/java/edu/duke/bookpublishing/books/lookup/BookLookupService.java
@@ -70,9 +70,21 @@ public class BookLookupService {
 
     PublishedDate publishedDate = parsePublishedDate(textOrNull(record.path("publish_date")));
 
+    String coverIsbn = isbn13 != null ? isbn13 : isbn10;
+    String coverImageUrl =
+        coverIsbn != null
+            ? "https://covers.openlibrary.org/b/isbn/" + coverIsbn + "-L.jpg?default=false"
+            : null;
+
     BookLookupResponse response =
         new BookLookupResponse(
-            title, author, isbn13, isbn10, publishedDate.year(), publishedDate.month(), null);
+            title,
+            author,
+            isbn13,
+            isbn10,
+            publishedDate.year(),
+            publishedDate.month(),
+            coverImageUrl);
 
     return BookLookupResult.lookup(response);
   }

--- a/backend/src/main/java/edu/duke/bookpublishing/books/lookup/OpenLibraryClient.java
+++ b/backend/src/main/java/edu/duke/bookpublishing/books/lookup/OpenLibraryClient.java
@@ -11,6 +11,7 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -22,6 +23,7 @@ import org.springframework.stereotype.Component;
 public class OpenLibraryClient {
 
   private static final String BASE_URL = "https://openlibrary.org/api/books";
+  private static final String COVERS_URL = "https://covers.openlibrary.org/b/isbn/";
   private static final Logger logger = LoggerFactory.getLogger(OpenLibraryClient.class);
 
   private final ObjectMapper objectMapper;
@@ -30,7 +32,10 @@ public class OpenLibraryClient {
   private String userAgent;
 
   private final HttpClient httpClient =
-      HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(5)).build();
+      HttpClient.newBuilder()
+          .connectTimeout(Duration.ofSeconds(5))
+          .followRedirects(HttpClient.Redirect.NORMAL)
+          .build();
 
   public JsonNode fetchByIsbn(String isbn) {
     String key = "ISBN:" + isbn;
@@ -67,4 +72,46 @@ public class OpenLibraryClient {
       throw new IllegalStateException("Open Library API request failed", ex);
     }
   }
+
+  public CoverDownloadResult downloadCoverByIsbn(String isbn) {
+    String url = COVERS_URL + isbn + "-L.jpg?default=false";
+
+    HttpRequest request =
+        HttpRequest.newBuilder(URI.create(url))
+            .timeout(Duration.ofSeconds(10))
+            .header("User-Agent", userAgent)
+            .GET()
+            .build();
+
+    try {
+      HttpResponse<byte[]> response =
+          httpClient.send(request, HttpResponse.BodyHandlers.ofByteArray());
+      if (response.statusCode() == 404) {
+        throw new NotFoundException("No cover found for ISBN: " + isbn);
+      }
+      if (response.statusCode() >= 400) {
+        throw new IllegalStateException(
+            "OpenLibrary cover download failed: HTTP " + response.statusCode());
+      }
+
+      byte[] data = response.body();
+      if (data == null || data.length == 0) {
+        throw new NotFoundException("No cover found for ISBN: " + isbn);
+      }
+
+      String contentType =
+          Optional.ofNullable(response.headers().firstValue("Content-Type").orElse(null))
+              .orElse("image/jpeg");
+
+      return new CoverDownloadResult(data, contentType);
+    } catch (InterruptedException ex) {
+      Thread.currentThread().interrupt();
+      throw new IllegalStateException("Cover download interrupted", ex);
+    } catch (IOException ex) {
+      logger.warn("Cover download failed for ISBN {}: {}", isbn, ex.getMessage());
+      throw new IllegalStateException("Cover download failed", ex);
+    }
+  }
+
+  public record CoverDownloadResult(byte[] data, String contentType) {}
 }

--- a/backend/src/main/java/edu/duke/bookpublishing/config/DataSeeder.java
+++ b/backend/src/main/java/edu/duke/bookpublishing/config/DataSeeder.java
@@ -60,7 +60,6 @@ public class DataSeeder implements CommandLineRunner {
         Integer seriesPosition = parseInteger(getValue(line, 8));
         BigDecimal coverPrice = parseBigDecimal(getValue(line, 9), BigDecimal.ZERO);
         BigDecimal printCost = parseBigDecimal(getValue(line, 10), BigDecimal.ZERO);
-        String coverImage = emptyToNull(getValue(line, 11));
 
         String[] dateParts = publicationDate.split("/");
         int month = Integer.parseInt(dateParts[0]);
@@ -79,7 +78,6 @@ public class DataSeeder implements CommandLineRunner {
                 .seriesPosition(seriesPosition)
                 .coverPrice(coverPrice)
                 .printCost(printCost)
-                .coverImage(coverImage)
                 .build();
 
         book = bookRepository.save(book);

--- a/backend/src/main/resources/application-dev.properties
+++ b/backend/src/main/resources/application-dev.properties
@@ -13,6 +13,10 @@ spring.datasource.driver-class-name=org.postgresql.Driver
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 
+# Multipart file upload limits
+spring.servlet.multipart.max-file-size=10MB
+spring.servlet.multipart.max-request-size=10MB
+
 # OpenAPI / Swagger (dev only)
 springdoc.api-docs.path=/api-docs
 springdoc.swagger-ui.path=/swagger-ui.html

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -11,3 +11,7 @@ app.cookie-secure=${COOKIE_SECURE:false}
 
 # External integrations
 app.openlibrary.user-agent=${OPENLIBRARY_USER_AGENT:book-publishing/1.0}
+
+# Cover image thumbnails
+app.covers.thumbnail-width=200
+app.covers.thumbnail-height=300

--- a/backend/src/test/java/edu/duke/bookpublishing/books/BookControllerTest.java
+++ b/backend/src/test/java/edu/duke/bookpublishing/books/BookControllerTest.java
@@ -82,8 +82,7 @@ class BookControllerTest {
         null,
         null,
         new BigDecimal("20.00"),
-        new BigDecimal("5.00"),
-        null);
+        new BigDecimal("5.00"));
   }
 
   @Test

--- a/deployment/nginx-dev.conf
+++ b/deployment/nginx-dev.conf
@@ -1,5 +1,6 @@
 server {
     listen 80;
+    client_max_body_size 10M;
 
     # API requests go to Spring Boot backend
     location /api/ {

--- a/deployment/nginx-prod.conf
+++ b/deployment/nginx-prod.conf
@@ -7,6 +7,7 @@ server {
 server {
     listen 443 ssl;
     server_name hypotheticalpublishing.colab.duke.edu;
+    client_max_body_size 10M;
 
     ssl_certificate /etc/letsencrypt/live/hypotheticalpublishing.colab.duke.edu/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/hypotheticalpublishing.colab.duke.edu/privkey.pem;

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,5 +1,6 @@
 server {
     listen 80;
+    client_max_body_size 10M;
     root /usr/share/nginx/html;
     index index.html;
 

--- a/frontend/src/api/generated/index.ts
+++ b/frontend/src/api/generated/index.ts
@@ -26,6 +26,7 @@ export { SaleResponse } from './models/SaleResponse';
 export type { UserResponse } from './models/UserResponse';
 
 export { AuthService } from './services/AuthService';
+export { BookCoversService } from './services/BookCoversService';
 export { BooksService } from './services/BooksService';
 export { SalesService } from './services/SalesService';
 export { SystemService } from './services/SystemService';

--- a/frontend/src/api/generated/models/BookDetailResponse.ts
+++ b/frontend/src/api/generated/models/BookDetailResponse.ts
@@ -59,10 +59,6 @@ export type BookDetailResponse = {
      */
     printCost?: number;
     /**
-     * Cover image URL
-     */
-    coverImage?: string;
-    /**
      * Total sales quantity to date
      */
     totalSalesToDate?: number;
@@ -82,5 +78,9 @@ export type BookDetailResponse = {
      * Total royalty earned by the author (both paid and unpaid)
      */
     totalRoyalty?: number;
+    /**
+     * Whether this book has a cover image
+     */
+    hasCover?: boolean;
 };
 

--- a/frontend/src/api/generated/models/BookRequest.ts
+++ b/frontend/src/api/generated/models/BookRequest.ts
@@ -54,10 +54,6 @@ export type BookRequest = {
      * Print cost (USD)
      */
     printCost: number;
-    /**
-     * Cover image file destination
-     */
-    coverImage?: string;
     coverPriceGreaterThanPrintCost?: boolean;
 };
 

--- a/frontend/src/api/generated/models/BookResponse.ts
+++ b/frontend/src/api/generated/models/BookResponse.ts
@@ -59,12 +59,12 @@ export type BookResponse = {
      */
     printCost?: number;
     /**
-     * Cover image URL
-     */
-    coverImage?: string;
-    /**
      * Total sales quantity to date
      */
     totalSalesToDate?: number;
+    /**
+     * Whether this book has a cover image
+     */
+    hasCover?: boolean;
 };
 

--- a/frontend/src/api/generated/services/BookCoversService.ts
+++ b/frontend/src/api/generated/services/BookCoversService.ts
@@ -1,0 +1,100 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { CancelablePromise } from '../core/CancelablePromise';
+import { OpenAPI } from '../core/OpenAPI';
+import { request as __request } from '../core/request';
+export class BookCoversService {
+    /**
+     * Get the full-size cover image
+     * @param bookId
+     * @returns string OK
+     * @throws ApiError
+     */
+    public static getCover(
+        bookId: number,
+    ): CancelablePromise<Array<string>> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/books/{bookId}/cover',
+            path: {
+                'bookId': bookId,
+            },
+        });
+    }
+    /**
+     * Upload or replace a book cover image
+     * @param bookId
+     * @param formData
+     * @returns string OK
+     * @throws ApiError
+     */
+    public static uploadCover(
+        bookId: number,
+        formData?: {
+            file: Blob;
+        },
+    ): CancelablePromise<Record<string, string>> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/books/{bookId}/cover',
+            path: {
+                'bookId': bookId,
+            },
+            formData: formData,
+            mediaType: 'multipart/form-data',
+        });
+    }
+    /**
+     * Remove a book cover image
+     * @param bookId
+     * @returns any OK
+     * @throws ApiError
+     */
+    public static deleteCover(
+        bookId: number,
+    ): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'DELETE',
+            url: '/api/books/{bookId}/cover',
+            path: {
+                'bookId': bookId,
+            },
+        });
+    }
+    /**
+     * Import cover from OpenLibrary using the book's ISBN
+     * @param bookId
+     * @returns string OK
+     * @throws ApiError
+     */
+    public static importCover(
+        bookId: number,
+    ): CancelablePromise<Record<string, string>> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/books/{bookId}/cover/import',
+            path: {
+                'bookId': bookId,
+            },
+        });
+    }
+    /**
+     * Get the cover thumbnail
+     * @param bookId
+     * @returns string OK
+     * @throws ApiError
+     */
+    public static getCoverThumbnail(
+        bookId: number,
+    ): CancelablePromise<Array<string>> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/books/{bookId}/cover/thumbnail',
+            path: {
+                'bookId': bookId,
+            },
+        });
+    }
+}


### PR DESCRIPTION
## Issues

Partially resolves #112 — backend portion only (upload, storage, thumbnail generation, OpenLibrary import, delete). Frontend display (book list thumbnails, detail large view, upload UI) still needed.

Partially resolves #101 — ISBN lookup response now includes `coverImageUrl` from OpenLibrary, and the import endpoint downloads a copy of the cover (per req 2.3.2.3, no hotlinking).

## Summary

Ev2 def 15 adds an optional cover image field to books. Req 1.14 requires server-side thumbnail scaling (not HTML-scaled full images). Req 2.3.1.3 specifies JPEG, GIF, PNG, and WEBP as accepted formats. Req 2.4.2 requires covers to be removable and replaceable. Req 2.3.2.3 requires that external DB import obtains a copy of the image rather than hotlinking.

This PR implements the full backend for all of the above: image upload with validation, pre-generated thumbnails, dedicated REST endpoints for serving/deleting covers, and an endpoint to import covers from OpenLibrary by ISBN.

## Files Changed

| File | Why |
|---|---|
| `backend/build.gradle` | Add [Thumbnailator](https://github.com/coobird/thumbnailator) library — a Java image resizing library used to generate thumbnails per req 1.14 |
| `application.properties` | Thumbnail dimension config (200x300) |
| `application-dev.properties` | 10MB multipart upload limit for cover files |
| `Book.java` | Three new columns: `cover_image` (bytea), `cover_thumbnail` (bytea), `cover_content_type`. Both image columns use lazy fetch to avoid loading bytes on list queries |
| `cover/CoverService.java` | **New.** Validates uploads (content type allowlist + `ImageIO` magic bytes check), generates thumbnails, sets/clears cover fields on Book |
| `cover/CoverController.java` | **New.** Five endpoints at `/api/books/{id}/cover`: upload (POST), get full-size (GET), get thumbnail (GET /thumbnail), delete (DELETE), import from OpenLibrary (POST /import) |
| `BookResponse.java` | Add `hasCover` boolean so the frontend knows whether to request a thumbnail |
| `BookDetailResponse.java` | Same `hasCover` addition for detail view |
| `BookLookupResponse.java` | Add `coverImageUrl` — constructed OpenLibrary URL so the frontend can preview the cover during ISBN lookup |
| `BookLookupService.java` | Build the `coverImageUrl` from the resolved ISBN |
| `OpenLibraryClient.java` | Add `downloadCoverByIsbn()` to fetch cover bytes from OpenLibrary. Enable redirect following since their cover API returns 302s to archive.org CDN |
| `nginx-dev.conf`, `nginx-prod.conf`, `frontend/nginx.conf` | `client_max_body_size 10M` to match Spring's multipart limit |
| `frontend/src/api/generated/*` | Auto-generated OpenAPI client types reflecting the new endpoints and DTO fields |

## Technical Decisions

**Database storage (bytea) vs. filesystem/S3**: Chose bytea columns for simplicity — cover data is atomic with the book record, no volume mounts or external services needed, and Hibernate `ddl-auto=update` handles the migration. Tradeoff is that large covers increase DB size, but the 10MB limit and typical cover sizes (~100KB-2MB) make this acceptable.

**Pre-generated thumbnails vs. on-the-fly resizing**: Thumbnails are generated once on upload and stored alongside the original. This avoids CPU cost on every list page load. The cost is ~2x storage per cover, but thumbnails are small (~5-20KB).

**Magic bytes validation via `ImageIO.read()`**: We don't trust the `Content-Type` header alone — a renamed `.txt` file with a `image/jpeg` content type would pass a header-only check. `ImageIO.read()` actually decodes the image, rejecting anything that isn't a real image.

**Lazy fetch on cover columns**: Without `@Basic(fetch = FetchType.LAZY)`, every `SELECT` on Book would load the full image bytes. Lazy fetch ensures `GET /api/books` (list) doesn't pull megabytes of image data per row.