### PR TITLE
fix: punctuation-aware author search

### DIFF
--- a/backend/src/main/java/edu/duke/bookpublishing/books/BookRepository.java
+++ b/backend/src/main/java/edu/duke/bookpublishing/books/BookRepository.java
@@ -25,7 +25,8 @@ public interface BookRepository extends JpaRepository<Book, Long>, JpaSpecificat
       """
           select distinct b.author
           from Book b
-          where lower(replace(b.author, '.', '')) like concat('%', lower(replace(:query, '.', '')), '%')
+          where replace(replace(replace(lower(b.author), '.', ''), '''', ''), '-', '')
+            like concat('%', replace(replace(replace(lower(:query), '.', ''), '''', ''), '-', ''), '%')
           order by lower(b.author) asc
           """)
   List<String> findDistinctAuthors(@Param("query") String query);
@@ -34,8 +35,27 @@ public interface BookRepository extends JpaRepository<Book, Long>, JpaSpecificat
       """
           select distinct b.author
           from Book b
-          where lower(replace(b.author, '.', '')) like concat('%', lower(replace(:query, '.', '')), '%')
+          where replace(replace(replace(lower(b.author), '.', ''), '''', ''), '-', '')
+            like concat('%', replace(replace(replace(lower(:query), '.', ''), '''', ''), '-', ''), '%')
           order by lower(b.author) asc
           """)
   Page<String> findDistinctAuthors(@Param("query") String query, Pageable pageable);
+
+  @Query(
+      """
+          select distinct b.author
+          from Book b
+          where lower(b.author) like concat('%', lower(:query), '%')
+          order by lower(b.author) asc
+          """)
+  List<String> findDistinctAuthorsLiteral(@Param("query") String query);
+
+  @Query(
+      """
+          select distinct b.author
+          from Book b
+          where lower(b.author) like concat('%', lower(:query), '%')
+          order by lower(b.author) asc
+          """)
+  Page<String> findDistinctAuthorsLiteral(@Param("query") String query, Pageable pageable);
 }

--- a/backend/src/main/java/edu/duke/bookpublishing/books/BookService.java
+++ b/backend/src/main/java/edu/duke/bookpublishing/books/BookService.java
@@ -39,6 +39,9 @@ public class BookService {
     if (normalizedQuery == null || normalizedQuery.isBlank()) {
       return List.of();
     }
+    if (BookSpecifications.containsAuthorPunctuation(normalizedQuery)) {
+      return bookRepository.findDistinctAuthorsLiteral(normalizedQuery);
+    }
     return bookRepository.findDistinctAuthors(normalizedQuery);
   }
 
@@ -46,6 +49,9 @@ public class BookService {
     String normalizedQuery = StringUtils.normalizeWhitespace(query);
     if (normalizedQuery == null || normalizedQuery.isBlank()) {
       return Page.empty(pageable);
+    }
+    if (BookSpecifications.containsAuthorPunctuation(normalizedQuery)) {
+      return bookRepository.findDistinctAuthorsLiteral(normalizedQuery, pageable);
     }
     return bookRepository.findDistinctAuthors(normalizedQuery, pageable);
   }

--- a/backend/src/main/java/edu/duke/bookpublishing/books/BookSpecifications.java
+++ b/backend/src/main/java/edu/duke/bookpublishing/books/BookSpecifications.java
@@ -39,20 +39,43 @@ public final class BookSpecifications {
     String lowerTerm = term.toLowerCase();
     // Normalize term for ISBN search by removing dashes (def 12)
     String normalizedTerm = lowerTerm.replaceAll("-", "");
-    // Normalize term for author search by removing periods (e.g. "JRR" matches "J.R.R.")
-    String authorTerm = lowerTerm.replaceAll("\\.", "");
+
+    // Author matching: if the user typed punctuation (. ' -), match literally;
+    // otherwise strip those characters from the DB value for lenient matching.
+    boolean hasAuthorPunctuation = containsAuthorPunctuation(lowerTerm);
+    Predicate authorPredicate;
+    if (hasAuthorPunctuation) {
+      authorPredicate = cb.like(cb.lower(bookPath.get("author")), "%" + lowerTerm + "%");
+    } else {
+      authorPredicate =
+          cb.like(
+              cb.function(
+                  "REPLACE",
+                  String.class,
+                  cb.function(
+                      "REPLACE",
+                      String.class,
+                      cb.function(
+                          "REPLACE",
+                          String.class,
+                          cb.lower(bookPath.get("author")),
+                          cb.literal("."),
+                          cb.literal("")),
+                      cb.literal("'"),
+                      cb.literal("")),
+                  cb.literal("-"),
+                  cb.literal("")),
+              "%" + lowerTerm + "%");
+    }
 
     return cb.or(
         cb.like(cb.lower(bookPath.get("title")), "%" + lowerTerm + "%"),
-        cb.like(
-            cb.function(
-                "REPLACE",
-                String.class,
-                cb.lower(bookPath.get("author")),
-                cb.literal("."),
-                cb.literal("")),
-            "%" + authorTerm + "%"),
+        authorPredicate,
         cb.like(cb.lower(bookPath.get("isbn13")), "%" + normalizedTerm + "%"),
         cb.like(cb.lower(bookPath.get("isbn10")), "%" + normalizedTerm + "%"));
+  }
+
+  static boolean containsAuthorPunctuation(String s) {
+    return s.chars().anyMatch(c -> c == '.' || c == '\'' || c == '-');
   }
 }

--- a/backend/src/test/java/edu/duke/bookpublishing/books/BookControllerTest.java
+++ b/backend/src/test/java/edu/duke/bookpublishing/books/BookControllerTest.java
@@ -645,6 +645,118 @@ class BookControllerTest {
         .andExpect(jsonPath("$.content", hasSize(1)));
   }
 
+  @Test
+  void searchBooksWithPeriodMatchesLiterally() throws Exception {
+    Cookie token = login();
+    createBook(
+        token,
+        new BookRequest(
+            "The Hobbit",
+            "Tolkien, J.R.R.",
+            "9780547928227",
+            null,
+            1937,
+            9,
+            new BigDecimal("0.5")));
+    createBook(
+        token,
+        new BookRequest(
+            "Some Book", "Murray, Bill", "9780547928234", null, 2000, 1, new BigDecimal("0.5")));
+
+    // "R.R." contains punctuation → literal match → only Tolkien
+    mockMvc
+        .perform(get("/api/books").cookie(token).param("query", "R.R."))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.content", hasSize(1)))
+        .andExpect(jsonPath("$.content[0].author").value("Tolkien, J.R.R."));
+
+    // "rr" has no punctuation → lenient match → both Tolkien (jrr) and Murray (murray)
+    mockMvc
+        .perform(get("/api/books").cookie(token).param("query", "rr"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.content", hasSize(2)));
+  }
+
+  @Test
+  void searchBooksWithApostropheMatchesLiterally() throws Exception {
+    Cookie token = login();
+    createBook(
+        token,
+        new BookRequest(
+            "At Swim", "O'Brien, Flann", "9780141182681", null, 1939, 3, new BigDecimal("0.5")));
+
+    // "O'Brien" contains punctuation → literal → matches
+    mockMvc
+        .perform(get("/api/books").cookie(token).param("query", "O'Brien"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.content", hasSize(1)))
+        .andExpect(jsonPath("$.content[0].author").value("O'Brien, Flann"));
+
+    // "obrien" no punctuation → lenient → still matches (strips apostrophe from DB)
+    mockMvc
+        .perform(get("/api/books").cookie(token).param("query", "obrien"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.content", hasSize(1)))
+        .andExpect(jsonPath("$.content[0].author").value("O'Brien, Flann"));
+  }
+
+  @Test
+  void searchBooksWithHyphenMatchesLiterally() throws Exception {
+    Cookie token = login();
+    createBook(
+        token,
+        new BookRequest(
+            "Nausea", "Sartre, Jean-Paul", "9780811220309", null, 1938, 1, new BigDecimal("0.5")));
+
+    // "Jean-Paul" contains punctuation → literal → matches
+    mockMvc
+        .perform(get("/api/books").cookie(token).param("query", "Jean-Paul"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.content", hasSize(1)))
+        .andExpect(jsonPath("$.content[0].author").value("Sartre, Jean-Paul"));
+
+    // "jeanpaul" no punctuation → lenient → still matches (strips hyphen from DB)
+    mockMvc
+        .perform(get("/api/books").cookie(token).param("query", "jeanpaul"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.content", hasSize(1)))
+        .andExpect(jsonPath("$.content[0].author").value("Sartre, Jean-Paul"));
+  }
+
+  @Test
+  void authorAutocompletePunctuationAware() throws Exception {
+    Cookie token = login();
+    createBook(
+        token,
+        new BookRequest(
+            "The Hobbit",
+            "Tolkien, J.R.R.",
+            "9780547928227",
+            null,
+            1937,
+            9,
+            new BigDecimal("0.5")));
+    createBook(
+        token,
+        new BookRequest(
+            "Some Book", "Murray, Bill", "9780547928234", null, 2000, 1, new BigDecimal("0.5")));
+
+    // "R.R." literal → only Tolkien
+    mockMvc
+        .perform(
+            get("/api/books/authors").cookie(token).param("query", "R.R.").param("showAll", "true"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.content", hasSize(1)))
+        .andExpect(jsonPath("$.content[0]").value("Tolkien, J.R.R."));
+
+    // "rr" lenient → both
+    mockMvc
+        .perform(
+            get("/api/books/authors").cookie(token).param("query", "rr").param("showAll", "true"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.content", hasSize(2)));
+  }
+
   private Long createBook(Cookie token, BookRequest request) throws Exception {
     MvcResult result =
         mockMvc


### PR DESCRIPTION
Closes #91

## Summary

Book search (req 2.1.2) and author autocomplete (req 2.3.1.1) previously stripped periods from both the search term and database value before matching, so searching `R.R.` collapsed to `rr` and matched any author containing those letters (e.g. `Murray`). This fix makes the search punctuation-aware: if the user typed punctuation, match literally; if they didn't, strip punctuation from the database value for lenient matching.

Punctuation characters handled: `.` `'` `-`

## Files changed

- **BookSpecifications.java** — `termMatchesAnyField()` now branches on whether the search term contains author punctuation. Literal path does a plain lowercase LIKE; lenient path strips all three characters from the DB value via nested `REPLACE` calls.
- **BookRepository.java** — Existing `findDistinctAuthors` JPQL updated to strip `.` `'` `-` (was only stripping `.`). Added `findDistinctAuthorsLiteral` overloads for the literal matching path.
- **BookService.java** — Routes to `findDistinctAuthorsLiteral` when the query contains author punctuation, otherwise uses the normalized `findDistinctAuthors`.
- **BookControllerTest.java** — Four new integration tests covering period, apostrophe, hyphen, and author autocomplete behavior in both literal and lenient modes.

## Technical decisions

- Punctuation detection is a simple character check (`containsAuthorPunctuation`) shared between `BookSpecifications` and `BookService` to keep the branching logic consistent across the Criteria API path and the JPQL path.
- The lenient path strips all three punctuation characters from the DB value (not just periods as before), so searches like `obrien` and `jeanpaul` also work.
- Separate `findDistinctAuthorsLiteral` query methods were added rather than building dynamic JPQL, keeping the repository interface straightforward.