### PR TITLE
fix: webp cover image support + thumbnail content-type

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     implementation 'com.auth0:java-jwt:4.4.0'
     implementation 'com.opencsv:opencsv:5.9'
     implementation 'net.coobird:thumbnailator:0.4.20'
+    implementation 'com.twelvemonkeys.imageio:imageio-webp:3.12.0'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/backend/src/main/java/edu/duke/bookpublishing/books/cover/CoverController.java
+++ b/backend/src/main/java/edu/duke/bookpublishing/books/cover/CoverController.java
@@ -68,7 +68,7 @@ public class CoverController {
       throw new ResponseStatusException(HttpStatus.NOT_FOUND, "No cover image");
     }
 
-    return buildImageResponse(book.getCoverThumbnail(), book.getCoverContentType());
+    return buildImageResponse(book.getCoverThumbnail(), "image/png");
   }
 
   @Operation(operationId = "deleteCover", summary = "Remove a book cover image")

--- a/backend/src/main/java/edu/duke/bookpublishing/books/cover/CoverService.java
+++ b/backend/src/main/java/edu/duke/bookpublishing/books/cover/CoverService.java
@@ -91,15 +91,10 @@ public class CoverService {
 
   private byte[] generateThumbnail(byte[] original, String contentType) {
     try {
-      String formatName = contentType.substring(contentType.indexOf('/') + 1);
-      if ("webp".equals(formatName)) {
-        formatName = "png";
-      }
-
       ByteArrayOutputStream out = new ByteArrayOutputStream();
       Thumbnails.of(new ByteArrayInputStream(original))
           .size(thumbnailWidth, thumbnailHeight)
-          .outputFormat(formatName)
+          .outputFormat("png")
           .toOutputStream(out);
       return out.toByteArray();
     } catch (IOException e) {


### PR DESCRIPTION
## Summary
- WebP uploads passed the content-type allowlist but failed at `ImageIO.read()` (returns null) because Java has no built-in WebP reader. Added TwelveMonkeys `imageio-webp` (pure Java, no native deps) to fix this.
- Thumbnails are always output as PNG but the thumbnail endpoint was serving them with the original content type (e.g. `image/webp`). Now correctly serves `image/png`.

## Files changed
- `backend/build.gradle` — added `com.twelvemonkeys.imageio:imageio-webp:3.12.0`
- `CoverService.java` — simplified `generateThumbnail` to always use `png` output format
- `CoverController.java` — thumbnail endpoint now returns `image/png` content type