### PR TITLE
refactor: extract shared utils and fix formatting inconsistencies

### DIFF
--- a/frontend/src/pages/dashboard/crud-dashboard/components/AuthorList.tsx
+++ b/frontend/src/pages/dashboard/crud-dashboard/components/AuthorList.tsx
@@ -20,6 +20,7 @@ import {
 import * as React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { AuthorsService, type AuthorResponse } from '../../../../api';
+import { formatCurrency } from '../../../../utils/formatting';
 import { useDebounce } from '../../../../hooks/useDebounce';
 import { useServerDataGrid } from '../../../../hooks/useServerDataGrid';
 import { useDialogs } from '../hooks/useDialogs/useDialogs';
@@ -27,8 +28,6 @@ import useNotifications from '../hooks/useNotifications/useNotifications';
 import PageContainer from './PageContainer';
 import SortDialog, { type SortOption } from './SortDialog';
 import StandardDataGrid from './StandardDataGrid';
-
-const currencyFormatter = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' });
 
 const AUTHOR_SORT_OPTIONS: SortOption[] = [
   { field: 'name', label: 'Name' },
@@ -136,21 +135,21 @@ export default function AuthorList() {
         headerName: 'Total Royalty',
         type: 'number',
         width: 140,
-        valueFormatter: (value) => (value != null ? currencyFormatter.format(Number(value)) : ''),
+        valueFormatter: (value) => (value != null ? formatCurrency(Number(value)) : '—'),
       },
       {
         field: 'paidRoyalty',
         headerName: 'Paid Royalty',
         type: 'number',
         width: 130,
-        valueFormatter: (value) => (value != null ? currencyFormatter.format(Number(value)) : ''),
+        valueFormatter: (value) => (value != null ? formatCurrency(Number(value)) : '—'),
       },
       {
         field: 'unpaidRoyalty',
         headerName: 'Unpaid Royalty',
         type: 'number',
         width: 130,
-        valueFormatter: (value) => (value != null ? currencyFormatter.format(Number(value)) : ''),
+        valueFormatter: (value) => (value != null ? formatCurrency(Number(value)) : '—'),
       },
       {
         field: 'actions',

--- a/frontend/src/pages/dashboard/crud-dashboard/components/AuthorPayments.tsx
+++ b/frontend/src/pages/dashboard/crud-dashboard/components/AuthorPayments.tsx
@@ -36,6 +36,7 @@ import {
   Tooltip,
   Typography,
 } from '@mui/material';
+import PaidStatusChip from './PaidStatusChip';
 import * as React from 'react';
 import { useNavigate } from 'react-router-dom';
 import PageContainer from './PageContainer';
@@ -44,28 +45,17 @@ import {
   BooksService,
   SalesService,
   type AuthorPaymentGroupResponse,
-  type AuthorPaymentSaleResponse,
   type MarkAllPaidRequest,
   type MarkAllPaidResponse,
   type PagedResponseAuthorPaymentGroupResponse,
   type AuthorResponse,
 } from '../../../../api';
 import { useDebounce } from '../../../../hooks/useDebounce';
+import { formatCurrency, formatMonthYear } from '../../../../utils/formatting';
 import useNotifications from '../hooks/useNotifications/useNotifications';
-import { MONTH_NAMES_SHORT as MONTH_NAMES } from '../../../../constants/months';
 const INITIAL_PAGE_SIZE = 10;
 const SHOW_ALL_SIZE = -1;
 const PAGE_SIZE_OPTIONS = [10, 25, 50, 100];
-
-const currencyFormatter = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' });
-function formatCurrency(n?: number) {
-  if (n == null) return '';
-  return currencyFormatter.format(n);
-}
-function formatMonthYear(s: AuthorPaymentSaleResponse) {
-  if (s.saleYear && s.saleMonth) return `${MONTH_NAMES[(s.saleMonth ?? 1) - 1]} ${s.saleYear}`;
-  return '';
-}
 
 function unwrap<T>(r: unknown): T {
   if (r && typeof r === 'object') {
@@ -410,20 +400,20 @@ export default function AuthorPaymentsView() {
                                 </Typography>
                               </TableCell>
 
-                              <TableCell>{formatMonthYear(s)}</TableCell>
+                              <TableCell>
+                                {s.saleYear && s.saleMonth
+                                  ? formatMonthYear(s.saleMonth, s.saleYear)
+                                  : '—'}
+                              </TableCell>
 
                               <TableCell align="right">{s.quantitySold ?? '-'}</TableCell>
 
-                              <TableCell align="right">{formatCurrency(s.authorRoyalty)}</TableCell>
+                              <TableCell align="right">
+                                {s.authorRoyalty != null ? formatCurrency(s.authorRoyalty) : '—'}
+                              </TableCell>
 
                               <TableCell>
-                                <Chip
-                                  icon={s.hasAuthorBeenPaid ? <CheckCircleIcon /> : <PendingIcon />}
-                                  label={s.hasAuthorBeenPaid ? 'Paid' : 'Unpaid'}
-                                  color={s.hasAuthorBeenPaid ? 'success' : 'warning'}
-                                  size="small"
-                                  variant={s.hasAuthorBeenPaid ? 'filled' : 'outlined'}
-                                />
+                                <PaidStatusChip paid={s.hasAuthorBeenPaid} />
                               </TableCell>
                             </TableRow>
                           ))}

--- a/frontend/src/pages/dashboard/crud-dashboard/components/AuthorRoyaltyReportView.tsx
+++ b/frontend/src/pages/dashboard/crud-dashboard/components/AuthorRoyaltyReportView.tsx
@@ -15,6 +15,7 @@ import {
 import { useCallback, useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { SalesService, type RoyaltyReportResponse } from '../../../../api';
+import { formatCurrency } from '../../../../utils/formatting';
 import './AuthorRoyaltyReportView.css';
 
 export default function AuthorRoyaltyReportView() {
@@ -62,13 +63,6 @@ export default function AuthorRoyaltyReportView() {
   const getQuarterLabel = (quarter?: number) => {
     const labels = ['Q1', 'Q2', 'Q3', 'Q4'];
     return labels[(quarter ?? 1) - 1];
-  };
-
-  const formatCurrency = (value?: number) => {
-    return new Intl.NumberFormat('en-US', {
-      style: 'currency',
-      currency: 'USD',
-    }).format(value ?? 0);
   };
 
   const getGeneratedDate = () => {

--- a/frontend/src/pages/dashboard/crud-dashboard/components/AuthorShow.tsx
+++ b/frontend/src/pages/dashboard/crud-dashboard/components/AuthorShow.tsx
@@ -17,7 +17,12 @@ import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
 import Typography from '@mui/material/Typography';
 import * as React from 'react';
-import { MONTH_NAMES_SHORT as MONTH_NAMES } from '../../../../constants/months';
+import {
+  formatCurrency,
+  formatMonthYear,
+  formatPercent,
+  truncate,
+} from '../../../../utils/formatting';
 
 import { useNavigate, useParams } from 'react-router-dom';
 import {
@@ -108,8 +113,6 @@ export default function AuthorShow() {
     }
   }, [author?.id, navigate]);
 
-  const formatCurrency = (value?: number) =>
-    value != null ? value.toLocaleString('en-US', { style: 'currency', currency: 'USD' }) : '$0.00';
   if (isLoading) {
     return <FullPageLoader />;
   }
@@ -206,22 +209,28 @@ export default function AuthorShow() {
                         </TableCell>
                         <TableCell>
                           {book.publicationYear && book.publicationMonth
-                            ? `${MONTH_NAMES[book.publicationMonth - 1]} ${book.publicationYear}`
+                            ? formatMonthYear(book.publicationMonth, book.publicationYear)
                             : '—'}
                         </TableCell>
                         <TableCell align="right">
                           {book.distributorAuthorRoyaltyRate != null
-                            ? `${(Number(book.distributorAuthorRoyaltyRate) * 100).toFixed(0)}%`
+                            ? formatPercent(Number(book.distributorAuthorRoyaltyRate))
                             : '—'}
                         </TableCell>
                         <TableCell align="right">
                           {book.handsoldAuthorRoyaltyRate != null
-                            ? `${(Number(book.handsoldAuthorRoyaltyRate) * 100).toFixed(0)}%`
+                            ? formatPercent(Number(book.handsoldAuthorRoyaltyRate))
                             : '—'}
                         </TableCell>
-                        <TableCell align="right">{formatCurrency(book.totalRoyalty)}</TableCell>
-                        <TableCell align="right">{formatCurrency(book.paidRoyalty)}</TableCell>
-                        <TableCell align="right">{formatCurrency(book.unpaidRoyalty)}</TableCell>
+                        <TableCell align="right">
+                          {book.totalRoyalty != null ? formatCurrency(book.totalRoyalty) : '—'}
+                        </TableCell>
+                        <TableCell align="right">
+                          {book.paidRoyalty != null ? formatCurrency(book.paidRoyalty) : '—'}
+                        </TableCell>
+                        <TableCell align="right">
+                          {book.unpaidRoyalty != null ? formatCurrency(book.unpaidRoyalty) : '—'}
+                        </TableCell>
                       </TableRow>
                     ))}
                   </TableBody>
@@ -233,14 +242,12 @@ export default function AuthorShow() {
       </Box>
     );
   };
-  const truncate = (value: string | undefined, maxLength = 30) =>
-    value && value.length > maxLength ? `${value.slice(0, maxLength)}…` : (value ?? '');
   return (
     <PageContainer
       title={author?.name}
       breadcrumbs={[
         { title: 'Authors', path: '/authors' },
-        { title: truncate(author?.name) || 'Author' },
+        { title: author?.name ? truncate(author.name) : 'Author' },
       ]}
     >
       <Box sx={{ display: 'flex', flex: 1, width: '100%' }}>{renderShow()}</Box>

--- a/frontend/src/pages/dashboard/crud-dashboard/components/BookEdit.tsx
+++ b/frontend/src/pages/dashboard/crud-dashboard/components/BookEdit.tsx
@@ -12,6 +12,7 @@ import {
   type BookRequest,
   type BookResponse,
 } from '../../../../api';
+import { truncate } from '../../../../utils/formatting';
 import { validate as validateBook, parseFieldErrors } from './bookValidation';
 import useNotifications from '../hooks/useNotifications/useNotifications';
 import BookForm, { type BookFormState, type FormFieldValue } from './BookForm';
@@ -242,9 +243,6 @@ export default function BookEdit() {
     ) : null;
   }, [isLoading, error, book, bookId, handleSubmit, authorForBook]);
 
-  const truncate = (value: string | undefined, maxLength = 30) =>
-    value && value.length > maxLength ? `${value.slice(0, maxLength)}…` : (value ?? '');
-
   if (isLoading) {
     return <FullPageLoader />;
   }
@@ -253,7 +251,7 @@ export default function BookEdit() {
       title={book?.title ?? 'Edit Book'}
       breadcrumbs={[
         { title: 'Books', path: '/books' },
-        { title: truncate(book?.title) || 'Book', path: `/books/${bookId}` },
+        { title: book?.title ? truncate(book.title) : 'Book', path: `/books/${bookId}` },
         { title: 'Edit' },
       ]}
     >

--- a/frontend/src/pages/dashboard/crud-dashboard/components/BookForm.tsx
+++ b/frontend/src/pages/dashboard/crud-dashboard/components/BookForm.tsx
@@ -503,6 +503,7 @@ export default function BookForm(props: BookFormProps) {
               helperText={formErrors.publicationYear ?? ' '}
               fullWidth
               inputProps={{ min: 1900, max: 2100 }}
+              onWheel={(e) => (e.target as HTMLElement).blur()}
             />
           </Grid>
           <Grid size={{ xs: 12, sm: 6 }} sx={{ display: 'flex' }}>
@@ -534,6 +535,7 @@ export default function BookForm(props: BookFormProps) {
               helperText={formErrors.distributorAuthorRoyaltyRate ?? ' '}
               fullWidth
               inputProps={{ step: '0.01', min: 0, max: 1 }}
+              onWheel={(e) => (e.target as HTMLElement).blur()}
             />
           </Grid>
           <Grid size={{ xs: 12, sm: 6 }} sx={{ display: 'flex' }}>
@@ -547,6 +549,7 @@ export default function BookForm(props: BookFormProps) {
               helperText={formErrors.handsoldAuthorRoyaltyRate ?? ' '}
               fullWidth
               inputProps={{ step: '0.01', min: 0, max: 1 }}
+              onWheel={(e) => (e.target as HTMLElement).blur()}
             />
           </Grid>
           <Grid size={{ xs: 12, sm: 6 }} sx={{ display: 'flex' }}>
@@ -597,6 +600,7 @@ export default function BookForm(props: BookFormProps) {
               helperText={formErrors.seriesPosition ?? ' '}
               fullWidth
               inputProps={{ min: 1, step: 1 }}
+              onWheel={(e) => (e.target as HTMLElement).blur()}
             />
           </Grid>
           <Grid size={{ xs: 12, sm: 6 }} sx={{ display: 'flex' }}>
@@ -610,6 +614,7 @@ export default function BookForm(props: BookFormProps) {
               helperText={formErrors.coverPrice ?? ' '}
               fullWidth
               inputProps={{ step: '0.01', min: 0 }}
+              onWheel={(e) => (e.target as HTMLElement).blur()}
             />
           </Grid>
           <Grid size={{ xs: 12, sm: 6 }} sx={{ display: 'flex' }}>
@@ -623,6 +628,7 @@ export default function BookForm(props: BookFormProps) {
               helperText={formErrors.printCost ?? ' '}
               fullWidth
               inputProps={{ step: '0.01', min: 0 }}
+              onWheel={(e) => (e.target as HTMLElement).blur()}
             />
           </Grid>
 

--- a/frontend/src/pages/dashboard/crud-dashboard/components/BookList.tsx
+++ b/frontend/src/pages/dashboard/crud-dashboard/components/BookList.tsx
@@ -19,7 +19,7 @@ import {
 } from '@mui/x-data-grid';
 import * as React from 'react';
 import { useNavigate } from 'react-router-dom';
-import { MONTH_NAMES_SHORT as MONTH_NAMES } from '../../../../constants/months';
+import { formatMonthYear } from '../../../../utils/formatting';
 import { useDebounce } from '../../../../hooks/useDebounce';
 import { useServerDataGrid } from '../../../../hooks/useServerDataGrid';
 import { BooksService, type BookResponse, type PagedResponseBookResponse } from '../../../../api';
@@ -193,7 +193,7 @@ export default function BookList() {
           const year = row.publicationYear;
           const month = row.publicationMonth;
           if (year && month) {
-            return `${MONTH_NAMES[month - 1]} ${year}`;
+            return formatMonthYear(month, year);
           }
           return '';
         },

--- a/frontend/src/pages/dashboard/crud-dashboard/components/BookSalesList.tsx
+++ b/frontend/src/pages/dashboard/crud-dashboard/components/BookSalesList.tsx
@@ -1,11 +1,8 @@
-import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import DeleteIcon from '@mui/icons-material/Delete';
 import EditOutlinedIcon from '@mui/icons-material/EditOutlined';
-import PendingIcon from '@mui/icons-material/Pending';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
-import Chip from '@mui/material/Chip';
 import CircularProgress from '@mui/material/CircularProgress';
 import IconButton from '@mui/material/IconButton';
 import Paper from '@mui/material/Paper';
@@ -26,9 +23,10 @@ import dayjs, { type Dayjs } from 'dayjs';
 import * as React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { SalesService, type SaleResponse, type PagedResponseSaleResponse } from '../../../../api';
+import { formatCurrency, formatMonthYear } from '../../../../utils/formatting';
 import { useDialogs } from '../hooks/useDialogs/useDialogs';
 import useNotifications from '../hooks/useNotifications/useNotifications';
-import { MONTH_NAMES } from '../../../../constants/months';
+import PaidStatusChip from './PaidStatusChip';
 
 type Props = {
   bookId?: number;
@@ -137,11 +135,6 @@ export default function BookSalesList({
       }
     },
     [dialogs, load, notifications, onChange, reloadSales],
-  );
-
-  const currency = React.useMemo(
-    () => new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }),
-    [],
   );
 
   const saleToKey = React.useCallback((s: SaleResponse) => {
@@ -378,7 +371,7 @@ export default function BookSalesList({
             <TableBody>
               {filteredSortedSales.map((s) => {
                 const monthLabel =
-                  s.saleMonth && s.saleYear ? `${MONTH_NAMES[s.saleMonth - 1]} ${s.saleYear}` : '—';
+                  s.saleMonth && s.saleYear ? formatMonthYear(s.saleMonth, s.saleYear) : '—';
                 const computedAuthorRoyalty = s.authorRoyalty != null ? s.authorRoyalty : null;
                 return (
                   <TableRow
@@ -396,20 +389,16 @@ export default function BookSalesList({
 
                     <TableCell align="right">{s.quantitySold ?? 0}</TableCell>
                     <TableCell align="right">
-                      {currency.format(Number(s.publisherRevenue ?? 0))}
+                      {s.publisherRevenue != null
+                        ? formatCurrency(Number(s.publisherRevenue))
+                        : '—'}
                     </TableCell>
                     <TableCell align="right">
-                      {computedAuthorRoyalty != null ? currency.format(computedAuthorRoyalty) : '—'}
+                      {computedAuthorRoyalty != null ? formatCurrency(computedAuthorRoyalty) : '—'}
                     </TableCell>
 
                     <TableCell align="center">
-                      <Chip
-                        icon={s.hasAuthorBeenPaid ? <CheckCircleIcon /> : <PendingIcon />}
-                        label={s.hasAuthorBeenPaid ? 'Paid' : 'Unpaid'}
-                        color={s.hasAuthorBeenPaid ? 'success' : 'warning'}
-                        size="small"
-                        variant={s.hasAuthorBeenPaid ? 'filled' : 'outlined'}
-                      />
+                      <PaidStatusChip paid={s.hasAuthorBeenPaid} />
                     </TableCell>
 
                     <TableCell align="center" onClick={(e) => e.stopPropagation()}>

--- a/frontend/src/pages/dashboard/crud-dashboard/components/BookShow.tsx
+++ b/frontend/src/pages/dashboard/crud-dashboard/components/BookShow.tsx
@@ -13,7 +13,12 @@ import Typography from '@mui/material/Typography';
 import * as React from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import FullPageLoader from '../../../../components/FullPageLoader';
-import { MONTH_NAMES } from '../../../../constants/months';
+import {
+  formatCurrency,
+  formatMonthYear,
+  formatPercent,
+  truncate,
+} from '../../../../utils/formatting';
 import BookSalesList from '../components/BookSalesList';
 import FinancialSummary from '../components/FinancialSummary';
 import {
@@ -132,16 +137,6 @@ export default function BookShow() {
     navigate(backPath);
   }, [navigate, backPath]);
 
-  const formatPublicationDate = (year?: number, month?: number) => {
-    if (!year || !month) return '—';
-    return `${MONTH_NAMES[month - 1]} ${year}`;
-  };
-
-  const formatRoyaltyRate = (rate?: number) => {
-    if (rate == null) return '—';
-    return `${(rate * 100).toFixed(0)}%`;
-  };
-
   const renderShow = React.useMemo(() => {
     if (isLoading) {
       return (
@@ -248,7 +243,9 @@ export default function BookShow() {
             <Paper sx={{ px: 2, py: 1 }}>
               <Typography variant="overline">Publication Date</Typography>
               <Typography variant="body1" sx={{ mb: 1 }}>
-                {formatPublicationDate(book.publicationYear, book.publicationMonth)}
+                {book.publicationYear && book.publicationMonth
+                  ? formatMonthYear(book.publicationMonth, book.publicationYear)
+                  : '—'}
               </Typography>
             </Paper>
           </Grid>
@@ -257,7 +254,9 @@ export default function BookShow() {
             <Paper sx={{ px: 2, py: 1 }}>
               <Typography variant="overline">Distributor Royalty Rate</Typography>
               <Typography variant="body1" sx={{ mb: 1 }}>
-                {formatRoyaltyRate(book.distributorAuthorRoyaltyRate)}
+                {book.distributorAuthorRoyaltyRate != null
+                  ? formatPercent(book.distributorAuthorRoyaltyRate)
+                  : '—'}
               </Typography>
             </Paper>
           </Grid>
@@ -266,7 +265,9 @@ export default function BookShow() {
             <Paper sx={{ px: 2, py: 1 }}>
               <Typography variant="overline">Handsold Royalty Rate</Typography>
               <Typography variant="body1" sx={{ mb: 1 }}>
-                {formatRoyaltyRate(book.handsoldAuthorRoyaltyRate)}
+                {book.handsoldAuthorRoyaltyRate != null
+                  ? formatPercent(book.handsoldAuthorRoyaltyRate)
+                  : '—'}
               </Typography>
             </Paper>
           </Grid>
@@ -286,7 +287,7 @@ export default function BookShow() {
             <Paper sx={{ px: 2, py: 1 }}>
               <Typography variant="overline">Cover Price</Typography>
               <Typography variant="body1" sx={{ mb: 1 }}>
-                {book.coverPrice != null ? `$${Number(book.coverPrice).toFixed(2)}` : '—'}
+                {book.coverPrice != null ? formatCurrency(Number(book.coverPrice)) : '—'}
               </Typography>
             </Paper>
           </Grid>
@@ -295,7 +296,7 @@ export default function BookShow() {
             <Paper sx={{ px: 2, py: 1 }}>
               <Typography variant="overline">Print Cost</Typography>
               <Typography variant="body1" sx={{ mb: 1 }}>
-                {book.printCost != null ? `$${Number(book.printCost).toFixed(2)}` : '—'}
+                {book.printCost != null ? formatCurrency(Number(book.printCost)) : '—'}
               </Typography>
             </Paper>
           </Grid>
@@ -355,12 +356,7 @@ export default function BookShow() {
     navigate,
   ]);
 
-  const truncate = React.useCallback((value: string | undefined, maxLength = 30) => {
-    if (!value) return value;
-    return value.length > maxLength ? `${value.slice(0, maxLength)}…` : value;
-  }, []);
-
-  const breadcrumbTitle = truncate(book?.title, 30) ?? 'Book';
+  const breadcrumbTitle = book?.title ? truncate(book.title, 30) : 'Book';
 
   if (isLoading) {
     return <FullPageLoader />;

--- a/frontend/src/pages/dashboard/crud-dashboard/components/FinancialSummary.tsx
+++ b/frontend/src/pages/dashboard/crud-dashboard/components/FinancialSummary.tsx
@@ -1,12 +1,12 @@
-import React from 'react';
+import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
+import MoneyOffIcon from '@mui/icons-material/MoneyOff';
+import Box from '@mui/material/Box';
+import CircularProgress from '@mui/material/CircularProgress';
 import Grid from '@mui/material/Grid';
 import Paper from '@mui/material/Paper';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
-import CircularProgress from '@mui/material/CircularProgress';
-import Box from '@mui/material/Box';
-import MoneyOffIcon from '@mui/icons-material/MoneyOff';
-import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
+import { formatCurrency } from '../../../../utils/formatting';
 
 type Props = {
   isLoading?: boolean;
@@ -33,11 +33,6 @@ export default function FinancialSummary({ isLoading, summary }: Props) {
     totalQuantitySold: toNumber(summary.totalSalesToDate),
   };
 
-  const currency = React.useMemo(
-    () => new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }),
-    [],
-  );
-
   if (isLoading) {
     return (
       <Box sx={{ display: 'flex', justifyContent: 'center', py: 3 }}>
@@ -54,7 +49,7 @@ export default function FinancialSummary({ isLoading, summary }: Props) {
         <Grid size={{ xs: 12, sm: 6, md: 2 }} sx={{ display: 'flex' }}>
           <Paper sx={{ p: 2, width: '100%' }}>
             <Typography variant="caption">Publisher Revenue</Typography>
-            <Typography variant="h6">{currency.format(totals.publisherRevenue)}</Typography>
+            <Typography variant="h6">{formatCurrency(totals.publisherRevenue)}</Typography>
           </Paper>
         </Grid>
 
@@ -62,7 +57,7 @@ export default function FinancialSummary({ isLoading, summary }: Props) {
           <Paper sx={{ p: 2, width: '100%' }}>
             <Typography variant="caption">Author Royalty (Unpaid)</Typography>
             <Stack direction="row" alignItems="center" spacing={1}>
-              <Typography variant="h6">{currency.format(totals.unpaidAuthorRoyalty)}</Typography>
+              <Typography variant="h6">{formatCurrency(totals.unpaidAuthorRoyalty)}</Typography>
               {totals.unpaidAuthorRoyalty > 0 ? <MoneyOffIcon color="warning" /> : null}
             </Stack>
           </Paper>
@@ -72,7 +67,7 @@ export default function FinancialSummary({ isLoading, summary }: Props) {
           <Paper sx={{ p: 2, width: '100%' }}>
             <Typography variant="caption">Author Royalty (Paid)</Typography>
             <Stack direction="row" alignItems="center" spacing={1}>
-              <Typography variant="h6">{currency.format(totals.paidAuthorRoyalty)}</Typography>
+              <Typography variant="h6">{formatCurrency(totals.paidAuthorRoyalty)}</Typography>
               <CheckCircleOutlineIcon color="success" />
             </Stack>
           </Paper>
@@ -81,7 +76,7 @@ export default function FinancialSummary({ isLoading, summary }: Props) {
         <Grid size={{ xs: 12, sm: 6, md: 2 }} sx={{ display: 'flex' }}>
           <Paper sx={{ p: 2, width: '100%' }}>
             <Typography variant="caption">Author Royalty (Total)</Typography>
-            <Typography variant="h6">{currency.format(totals.totalAuthorRoyalty)}</Typography>
+            <Typography variant="h6">{formatCurrency(totals.totalAuthorRoyalty)}</Typography>
           </Paper>
         </Grid>
 

--- a/frontend/src/pages/dashboard/crud-dashboard/components/PaidStatusChip.tsx
+++ b/frontend/src/pages/dashboard/crud-dashboard/components/PaidStatusChip.tsx
@@ -1,0 +1,16 @@
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import PendingIcon from '@mui/icons-material/Pending';
+import Chip from '@mui/material/Chip';
+
+/** Shared chip for displaying paid/unpaid status. */
+export default function PaidStatusChip({ paid }: { paid?: boolean }) {
+  return (
+    <Chip
+      icon={paid ? <CheckCircleIcon /> : <PendingIcon />}
+      label={paid ? 'Paid' : 'Unpaid'}
+      color={paid ? 'success' : 'warning'}
+      size="small"
+      variant={paid ? 'filled' : 'outlined'}
+    />
+  );
+}

--- a/frontend/src/pages/dashboard/crud-dashboard/components/SaleCreate.tsx
+++ b/frontend/src/pages/dashboard/crud-dashboard/components/SaleCreate.tsx
@@ -34,6 +34,10 @@ import * as React from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { BooksService, SaleRequest, SalesService, type BookResponse } from '../../../../api';
 import { isValidMonetaryInput } from '../../../../utils/monetary';
+import {
+  computeHandsoldRevenue,
+  computeRoyalty as computeRoyaltyUtil,
+} from '../../../../utils/royalty';
 import useNotifications from '../hooks/useNotifications/useNotifications';
 import PageContainer from './PageContainer';
 
@@ -55,9 +59,11 @@ function computePublisherRevenue(
     return publisherRevenue;
   }
   if (!book || quantity == null) return null;
-  const coverPrice = Number(book.coverPrice ?? 0);
-  const printCost = Number(book.printCost ?? 0);
-  return Number(((coverPrice - printCost) * quantity).toFixed(2));
+  return computeHandsoldRevenue(
+    Number(book.coverPrice ?? 0),
+    Number(book.printCost ?? 0),
+    quantity,
+  );
 }
 
 function computeRoyalty(
@@ -70,7 +76,7 @@ function computeRoyalty(
     saleSource === SaleRequest.saleSource.HAND_SOLD
       ? (book.handsoldAuthorRoyaltyRate ?? 0)
       : (book.distributorAuthorRoyaltyRate ?? 0);
-  return Number((revenue * rate).toFixed(2));
+  return computeRoyaltyUtil(revenue, rate);
 }
 
 interface SaleRecordInput {
@@ -618,7 +624,7 @@ export default function SaleCreate() {
                         onError={handleDateError(index)}
                         views={['year', 'month']}
                         openTo="year"
-                        format="MM/YYYY"
+                        format="MMM YYYY"
                         minDate={dayjs('1900-01-01')}
                         maxDate={dayjs()}
                         slotProps={{
@@ -626,7 +632,7 @@ export default function SaleCreate() {
                             size: 'small',
                             fullWidth: true,
                             error: !!record.errors.saleDate || !!record.dateError,
-                            placeholder: 'MM/YYYY',
+                            placeholder: 'MMM YYYY',
                             onFocus: () => activateRow(index),
                           },
                           field: { clearable: true },

--- a/frontend/src/pages/dashboard/crud-dashboard/components/SaleEdit.tsx
+++ b/frontend/src/pages/dashboard/crud-dashboard/components/SaleEdit.tsx
@@ -26,6 +26,10 @@ import {
 } from '../../../../api';
 import { MONTH_NAMES } from '../../../../constants/months';
 import { isValidMonetaryInput } from '../../../../utils/monetary';
+import {
+  computeHandsoldRevenue,
+  computeRoyalty as computeRoyaltyUtil,
+} from '../../../../utils/royalty';
 import useNotifications from '../hooks/useNotifications/useNotifications';
 import PageContainer from './PageContainer';
 
@@ -57,9 +61,11 @@ export default function SaleEdit() {
     if (saleSource === SaleRequest.saleSource.DISTRIBUTOR) {
       return parseFloat(publisherRevenue) || 0;
     }
-    const coverPrice = Number(selectedBook?.coverPrice ?? 0);
-    const printCost = Number(selectedBook?.printCost ?? 0);
-    return Number(((coverPrice - printCost) * quantitySold).toFixed(2));
+    return computeHandsoldRevenue(
+      Number(selectedBook?.coverPrice ?? 0),
+      Number(selectedBook?.printCost ?? 0),
+      quantitySold,
+    );
   }, [publisherRevenue, saleSource, selectedBook, quantitySold]);
 
   const computedRoyalty = React.useMemo(() => {
@@ -67,7 +73,7 @@ export default function SaleEdit() {
       saleSource === SaleRequest.saleSource.HAND_SOLD
         ? (selectedBook?.handsoldAuthorRoyaltyRate ?? 0)
         : (selectedBook?.distributorAuthorRoyaltyRate ?? 0);
-    return Number((computedRevenue * rate).toFixed(2));
+    return computeRoyaltyUtil(computedRevenue, rate);
   }, [computedRevenue, saleSource, selectedBook]);
 
   // Load sale and books
@@ -235,6 +241,7 @@ export default function SaleEdit() {
               label="Sale Year"
               fullWidth
               inputProps={{ min: 1900, max: 2100 }}
+              onWheel={(e) => (e.target as HTMLElement).blur()}
             />
           </Grid>
 
@@ -290,6 +297,7 @@ export default function SaleEdit() {
               label="Quantity Sold"
               fullWidth
               inputProps={{ min: 0 }}
+              onWheel={(e) => (e.target as HTMLElement).blur()}
             />
           </Grid>
 
@@ -330,6 +338,7 @@ export default function SaleEdit() {
               label="Comment"
               fullWidth
               inputProps={{ maxLength: 256 }}
+              helperText={`${comment.length}/256 characters`}
             />
           </Grid>
 

--- a/frontend/src/pages/dashboard/crud-dashboard/components/SaleImport.tsx
+++ b/frontend/src/pages/dashboard/crud-dashboard/components/SaleImport.tsx
@@ -31,14 +31,9 @@ import {
   type ParsingError,
   type SaleResponse,
 } from '../../../../api';
-import { MONTH_NAMES_SHORT as MONTH_NAMES } from '../../../../constants/months';
+import { formatCurrency, formatMonthYear } from '../../../../utils/formatting';
 import useNotifications from '../hooks/useNotifications/useNotifications';
 import PageContainer from './PageContainer';
-
-function formatMonthYear(sale: SaleResponse) {
-  if (!sale.saleMonth || !sale.saleYear) return '';
-  return `${MONTH_NAMES[sale.saleMonth - 1]} ${sale.saleYear}`;
-}
 
 type ErrorState = {
   csvErrors: ParsingError[];
@@ -265,14 +260,14 @@ export default function SaleImport() {
                   value={saleDate}
                   onChange={(v) => setSaleDate(v)}
                   views={['year', 'month']}
-                  format="MM/YYYY"
+                  format="MMM YYYY"
                   openTo="year"
                   minDate={dayjs('1900-01-01')}
                   maxDate={dayjs()}
                   slotProps={{
                     textField: {
                       size: 'small',
-                      placeholder: 'MM/YYYY',
+                      placeholder: 'MMM YYYY',
                       InputLabelProps: { shrink: true },
                     },
                     toolbar: { hidden: true },
@@ -346,20 +341,24 @@ export default function SaleImport() {
                   {previewSales.map((sale, index) => (
                     <TableRow key={`${sale.bookId ?? 'book'}-${index}`}>
                       <TableCell>{sale.bookTitle ?? `Book ${sale.bookId ?? ''}`}</TableCell>
-                      <TableCell>{sale.bookAuthor ?? '-'}</TableCell>
-                      <TableCell>{formatMonthYear(sale)}</TableCell>
+                      <TableCell>{sale.bookAuthor ?? '—'}</TableCell>
+                      <TableCell>
+                        {sale.saleMonth && sale.saleYear
+                          ? formatMonthYear(sale.saleMonth, sale.saleYear)
+                          : '—'}
+                      </TableCell>
                       <TableCell align="right">{sale.quantitySold ?? 0}</TableCell>
                       <TableCell align="right">
                         {sale.publisherRevenue != null
-                          ? `$${Number(sale.publisherRevenue).toFixed(2)}`
-                          : '-'}
+                          ? formatCurrency(Number(sale.publisherRevenue))
+                          : '—'}
                       </TableCell>
                       <TableCell align="right">
                         {sale.authorRoyalty != null
-                          ? `$${Number(sale.authorRoyalty).toFixed(2)}`
-                          : '-'}
+                          ? formatCurrency(Number(sale.authorRoyalty))
+                          : '—'}
                       </TableCell>
-                      <TableCell>{sale.comment ?? '-'}</TableCell>
+                      <TableCell>{sale.comment ?? '—'}</TableCell>
                     </TableRow>
                   ))}
                 </TableBody>

--- a/frontend/src/pages/dashboard/crud-dashboard/components/SaleList.tsx
+++ b/frontend/src/pages/dashboard/crud-dashboard/components/SaleList.tsx
@@ -1,14 +1,11 @@
 import AddIcon from '@mui/icons-material/Add';
-import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import DeleteIcon from '@mui/icons-material/Delete';
 import EditIcon from '@mui/icons-material/Edit';
-import PendingIcon from '@mui/icons-material/Pending';
 import RefreshIcon from '@mui/icons-material/Refresh';
 import UploadFileIcon from '@mui/icons-material/UploadFile';
 import Autocomplete from '@mui/material/Autocomplete';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
-import Chip from '@mui/material/Chip';
 import FormControl from '@mui/material/FormControl';
 import IconButton from '@mui/material/IconButton';
 import InputLabel from '@mui/material/InputLabel';
@@ -36,11 +33,12 @@ import {
   type SaleResponse,
   SalesService,
 } from '../../../../api';
-import { MONTH_NAMES_SHORT as MONTH_NAMES } from '../../../../constants/months';
+import { formatCurrency, formatMonthYear } from '../../../../utils/formatting';
 import { useServerDataGrid } from '../../../../hooks/useServerDataGrid';
 import { useDialogs } from '../hooks/useDialogs/useDialogs';
 import useNotifications from '../hooks/useNotifications/useNotifications';
 import PageContainer from './PageContainer';
+import PaidStatusChip from './PaidStatusChip';
 import StandardDataGrid from './StandardDataGrid';
 
 export default function SaleList() {
@@ -217,9 +215,8 @@ export default function SaleList() {
         headerName: 'Month/Year',
         width: 120,
         valueGetter: (_value, row) => {
-          if (row.saleYear && row.saleMonth)
-            return `${MONTH_NAMES[row.saleMonth - 1]} ${row.saleYear}`;
-          return '';
+          if (row.saleYear && row.saleMonth) return formatMonthYear(row.saleMonth, row.saleYear);
+          return '—';
         },
       },
       {
@@ -233,31 +230,20 @@ export default function SaleList() {
         headerName: 'Publisher Revenue',
         type: 'number',
         width: 160,
-        valueFormatter: (value) => (value != null ? `$${Number(value).toFixed(2)}` : ''),
+        valueFormatter: (value) => (value != null ? formatCurrency(Number(value)) : '—'),
       },
       {
         field: 'authorRoyalty',
         headerName: 'Author Royalty',
         type: 'number',
         width: 150,
-        valueFormatter: (value) => (value != null ? `$${Number(value).toFixed(2)}` : ''),
+        valueFormatter: (value) => (value != null ? formatCurrency(Number(value)) : '—'),
       },
       {
         field: 'hasAuthorBeenPaid',
         headerName: 'Paid Status',
         width: 140,
-        renderCell: (params) => {
-          const isPaid = params.row.hasAuthorBeenPaid;
-          return (
-            <Chip
-              icon={isPaid ? <CheckCircleIcon /> : <PendingIcon />}
-              label={isPaid ? 'Paid' : 'Unpaid'}
-              color={isPaid ? 'success' : 'warning'}
-              size="small"
-              variant={isPaid ? 'filled' : 'outlined'}
-            />
-          );
-        },
+        renderCell: (params) => <PaidStatusChip paid={params.row.hasAuthorBeenPaid} />,
       },
       {
         field: 'actions',
@@ -304,14 +290,14 @@ export default function SaleList() {
               value={startDate}
               onChange={(v) => setStartDate(v)}
               views={['year', 'month']}
-              format="MM/YYYY"
+              format="MMM YYYY"
               openTo="year"
               minDate={dayjs('1900-01-01')}
               maxDate={dayjs()}
               slotProps={{
                 textField: {
                   size: 'small',
-                  placeholder: 'MM/YYYY',
+                  placeholder: 'MMM YYYY',
                   InputLabelProps: { shrink: true },
                 },
                 toolbar: { hidden: true },
@@ -325,14 +311,14 @@ export default function SaleList() {
               value={endDate}
               onChange={(v) => setEndDate(v)}
               views={['year', 'month']}
-              format="MM/YYYY"
+              format="MMM YYYY"
               openTo="year"
               minDate={dayjs('1900-01-01')}
               maxDate={dayjs()}
               slotProps={{
                 textField: {
                   size: 'small',
-                  placeholder: 'MM/YYYY',
+                  placeholder: 'MMM YYYY',
                   InputLabelProps: { shrink: true },
                 },
                 toolbar: { hidden: true },

--- a/frontend/src/pages/dashboard/crud-dashboard/components/SaleShow.tsx
+++ b/frontend/src/pages/dashboard/crud-dashboard/components/SaleShow.tsx
@@ -1,12 +1,9 @@
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
-import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import DeleteIcon from '@mui/icons-material/Delete';
 import EditIcon from '@mui/icons-material/Edit';
-import PendingIcon from '@mui/icons-material/Pending';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
-import Chip from '@mui/material/Chip';
 import CircularProgress from '@mui/material/CircularProgress';
 import Divider from '@mui/material/Divider';
 import Grid from '@mui/material/Grid';
@@ -16,10 +13,11 @@ import Typography from '@mui/material/Typography';
 import * as React from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { BooksService, SalesService, type BookResponse, type SaleResponse } from '../../../../api';
-import { MONTH_NAMES } from '../../../../constants/months';
+import { formatCurrency, formatMonthYear } from '../../../../utils/formatting';
 import { useDialogs } from '../hooks/useDialogs/useDialogs';
 import useNotifications from '../hooks/useNotifications/useNotifications';
 import PageContainer from './PageContainer';
+import PaidStatusChip from './PaidStatusChip';
 
 export default function SaleShow() {
   const { saleId } = useParams();
@@ -106,11 +104,6 @@ export default function SaleShow() {
     navigate(backPath);
   }, [navigate, backPath]);
 
-  const formatDate = (year?: number, month?: number) => {
-    if (!year || !month) return '—';
-    return `${MONTH_NAMES[month - 1]} ${year}`;
-  };
-
   const renderShow = React.useMemo(() => {
     if (isLoading) {
       return (
@@ -194,7 +187,9 @@ export default function SaleShow() {
             <Paper sx={{ px: 2, py: 1 }}>
               <Typography variant="overline">Sale Period</Typography>
               <Typography variant="body1" sx={{ mb: 1 }}>
-                {formatDate(sale.saleYear, sale.saleMonth)}
+                {sale.saleYear && sale.saleMonth
+                  ? formatMonthYear(sale.saleMonth, sale.saleYear)
+                  : '—'}
               </Typography>
             </Paper>
           </Grid>
@@ -222,7 +217,9 @@ export default function SaleShow() {
             <Paper sx={{ px: 2, py: 1 }}>
               <Typography variant="overline">Publisher Revenue</Typography>
               <Typography variant="body1" sx={{ mb: 1 }}>
-                ${Number(sale.publisherRevenue || 0).toFixed(2)}
+                {sale.publisherRevenue != null
+                  ? formatCurrency(Number(sale.publisherRevenue))
+                  : '—'}
               </Typography>
             </Paper>
           </Grid>
@@ -230,7 +227,7 @@ export default function SaleShow() {
             <Paper sx={{ px: 2, py: 1 }}>
               <Typography variant="overline">Author Royalty</Typography>
               <Typography variant="body1" sx={{ mb: 1 }}>
-                ${Number(sale.authorRoyalty || 0).toFixed(2)}
+                {sale.authorRoyalty != null ? formatCurrency(Number(sale.authorRoyalty)) : '—'}
               </Typography>
             </Paper>
           </Grid>
@@ -246,13 +243,7 @@ export default function SaleShow() {
             <Paper sx={{ px: 2, py: 1 }}>
               <Typography variant="overline">Payment Status</Typography>
               <Box sx={{ mb: 1 }}>
-                <Chip
-                  icon={sale.hasAuthorBeenPaid ? <CheckCircleIcon /> : <PendingIcon />}
-                  label={sale.hasAuthorBeenPaid ? 'Paid' : 'Unpaid'}
-                  color={sale.hasAuthorBeenPaid ? 'success' : 'warning'}
-                  size="small"
-                  variant={sale.hasAuthorBeenPaid ? 'filled' : 'outlined'}
-                />
+                <PaidStatusChip paid={sale.hasAuthorBeenPaid} />
               </Box>
             </Paper>
           </Grid>

--- a/frontend/src/utils/formatting.ts
+++ b/frontend/src/utils/formatting.ts
@@ -1,0 +1,23 @@
+import { MONTH_NAMES } from '../constants/months';
+
+const currencyFormatter = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' });
+
+/** Format a number as USD currency with thousands separators. Callers handle null display. */
+export function formatCurrency(n: number): string {
+  return currencyFormatter.format(n);
+}
+
+/** Format month (1-12) and year as "January 2026". Callers handle null display. */
+export function formatMonthYear(month: number, year: number): string {
+  return `${MONTH_NAMES[month - 1]} ${year}`;
+}
+
+/** Format a decimal rate (0.0-1.0) as a percentage string like "50%". */
+export function formatPercent(rate: number): string {
+  return `${(rate * 100).toFixed(0)}%`;
+}
+
+/** Truncate a string to maxLength characters with ellipsis. */
+export function truncate(value: string, maxLength = 30): string {
+  return value.length > maxLength ? `${value.slice(0, maxLength)}…` : value;
+}

--- a/frontend/src/utils/royalty.ts
+++ b/frontend/src/utils/royalty.ts
@@ -1,0 +1,13 @@
+/** Compute publisher revenue for a hand-sold sale: (coverPrice - printCost) * quantity. */
+export function computeHandsoldRevenue(
+  coverPrice: number,
+  printCost: number,
+  quantity: number,
+): number {
+  return Number(((coverPrice - printCost) * quantity).toFixed(2));
+}
+
+/** Compute author royalty: revenue * rate. */
+export function computeRoyalty(revenue: number, rate: number): number {
+  return Number((revenue * rate).toFixed(2));
+}


### PR DESCRIPTION
## Related Issues

Part of the frontend refactoring series (PR B). Chains on #161 (PR A: dead code + data layer removal).

## Summary

The frontend had duplicated utility logic scattered across components: currency formatting (5 implementations, some missing thousands separators), month/year formatting (8 call sites), percentage formatting (3 call sites), royalty computation (2 call sites), truncation (4 implementations), and paid-status chips duplicated 4 times. There were also formatting bugs and display inconsistencies.

This PR extracts shared utils, fixes the formatting bugs, and standardizes display conventions — with zero behavioral change to business logic.

**What changed:**
- Currency values with 4+ digits now display thousands separators everywhere (was broken in BookShow, SaleShow, SaleList, SaleImport, AuthorList, BookSalesList, AuthorShow)
- Null/missing values consistently display as `—` (em dash) instead of a mix of `$0.00`, empty string, and `-`
- Date pickers standardized to `MMM YYYY` format instead of `MM/YYYY`
- Number inputs no longer change value on mouse scroll
- SaleEdit comment field now shows character counter (matches SaleCreate)

## Files Changed

**New files (3):**
- `utils/formatting.ts` — shared `formatCurrency`, `formatMonthYear`, `formatPercent`, `truncate` (single `Intl.NumberFormat` instance reused everywhere)
- `utils/royalty.ts` — shared `computeHandsoldRevenue`, `computeRoyalty` (pure math extracted from SaleCreate/SaleEdit)
- `PaidStatusChip.tsx` — shared component replacing 4 identical inline `<Chip>` blocks

**Modified files (15):**
- `BookShow` — uses shared currency, month/year, percent, truncate
- `AuthorShow` — uses shared currency, month/year, percent, truncate; fixes null royalty display
- `SaleShow` — uses shared currency, month/year; replaces inline chip with PaidStatusChip
- `SaleList` — uses shared currency, month/year; replaces inline chip; date picker format
- `SaleImport` — uses shared currency, month/year; standardizes null display; date picker format
- `FinancialSummary` — replaces local `useMemo` Intl.NumberFormat with shared import
- `AuthorPayments` — replaces local formatCurrency/formatMonthYear; replaces inline chip
- `AuthorRoyaltyReportView` — replaces per-call `new Intl.NumberFormat()` (perf bug) with shared import
- `BookSalesList` — replaces local `useMemo` Intl.NumberFormat; replaces inline chip
- `SaleCreate` — delegates math to shared royalty utils; date picker format
- `SaleEdit` — delegates math to shared royalty utils; adds onWheel blur + comment counter
- `BookForm` — adds onWheel blur to all 6 number inputs
- `BookEdit` — uses shared truncate
- `BookList` — uses shared formatMonthYear
- `AuthorList` — replaces local currencyFormatter with shared import

## Technical Decisions

- `formatCurrency` takes `number` (not `number | undefined`) — callers explicitly guard for null at the call site with `value != null ? formatCurrency(value) : '—'`. This makes nullability handling visible and consistent rather than hidden inside the formatter.
- AuthorRoyaltyReportView keeps `$0.00` for null values (zeroes are meaningful in financial report context) while all other components use `—`.
- SaleCreate/SaleEdit keep their sale-source branching logic locally and only delegate the pure math (`computeHandsoldRevenue`, `computeRoyalty`) to utils — the branching is UI-specific and doesn't belong in a utility.
- `onWheel` blur handler uses `(e.target as HTMLElement).blur()` — simplest fix for the browser scroll-to-change behavior on number inputs.