### PR TITLE
FIX: Adds more robust email checking on frontend

### DIFF
--- a/frontend/src/features/authors/authorValidation.ts
+++ b/frontend/src/features/authors/authorValidation.ts
@@ -1,4 +1,4 @@
-const EMAIL_REGEX = /(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])/;
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@.]+$/;
 
 export interface AuthorFormState {
   name: string;
@@ -12,7 +12,7 @@ export function validateAuthor(
   const errors: AuthorFormState['errors'] = {};
   if (!values.name.trim()) errors.name = 'Name is required';
   if (!values.email.trim()) errors.email = 'Email is required';
-  else if (!EMAIL_REGEX.test(values.email))
+  else if (!EMAIL_REGEX.test(values.email.toLowerCase().trim()))
     errors.email = 'Must be a valid email address';
   return errors;
 }

--- a/frontend/src/features/authors/authorValidation.ts
+++ b/frontend/src/features/authors/authorValidation.ts
@@ -1,3 +1,5 @@
+const EMAIL_REGEX = /(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])/;
+
 export interface AuthorFormState {
   name: string;
   email: string;
@@ -10,7 +12,7 @@ export function validateAuthor(
   const errors: AuthorFormState['errors'] = {};
   if (!values.name.trim()) errors.name = 'Name is required';
   if (!values.email.trim()) errors.email = 'Email is required';
-  else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(values.email))
+  else if (!EMAIL_REGEX.test(values.email))
     errors.email = 'Must be a valid email address';
   return errors;
 }


### PR DESCRIPTION
Replaces the existing email regex for frontend with a more robust regex. Also eliminates comparison against raw email and does it against the trimmed version, as that is what is sent to the backend (per L38 in `AuthorCreate.tsx`)

Closes #165 