### PR TITLE
FIX: Fixes non-number input for distributor/handsold royalty being accepted

### DIFF
--- a/frontend/src/features/books/BookCreate.tsx
+++ b/frontend/src/features/books/BookCreate.tsx
@@ -28,6 +28,12 @@ export default function BookCreate() {
 
   const notifications = useNotifications();
 
+  const normalizeRoyaltyRate = React.useCallback((value: unknown, fallback: number) => {
+    if (value == null || value === '') return fallback;
+    const rate = Number(value);
+    return Number.isNaN(rate) ? fallback : rate;
+  }, []);
+
   const [formState, setFormState] = React.useState<BookFormState>(() => ({
     values: INITIAL_FORM_VALUES,
     errors: {},
@@ -172,8 +178,11 @@ export default function BookCreate() {
         isbn10: formValues.isbn10 ?? undefined,
         publicationYear: formValues.publicationYear ?? new Date().getFullYear(),
         publicationMonth: formValues.publicationMonth ?? 1,
-        distributorAuthorRoyaltyRate: formValues.distributorAuthorRoyaltyRate ?? 0.5,
-        handsoldAuthorRoyaltyRate: formValues.handsoldAuthorRoyaltyRate ?? 0.2,
+        distributorAuthorRoyaltyRate: normalizeRoyaltyRate(
+          formValues.distributorAuthorRoyaltyRate,
+          0.5,
+        ),
+        handsoldAuthorRoyaltyRate: normalizeRoyaltyRate(formValues.handsoldAuthorRoyaltyRate, 0.2),
         seriesName: formValues.seriesName ?? undefined,
         seriesPosition: formValues.seriesPosition ?? undefined,
         coverPrice: formValues.coverPrice ?? 0,
@@ -214,7 +223,7 @@ export default function BookCreate() {
       }
       throw createError;
     }
-  }, [formValues, navigate, notifications, setFormErrors]);
+  }, [formValues, navigate, normalizeRoyaltyRate, notifications, setFormErrors]);
 
   return (
     <PageContainer

--- a/frontend/src/features/books/BookEdit.tsx
+++ b/frontend/src/features/books/BookEdit.tsx
@@ -17,6 +17,12 @@ import { useNotifications } from '@/hooks/useNotifications/useNotifications';
 import BookForm, { type BookFormState, type FormFieldValue } from './BookForm';
 import PageContainer from '@/components/PageContainer';
 
+const normalizeRoyaltyRate = (value: unknown, fallback: number) => {
+  if (value == null || value === '') return fallback;
+  const rate = Number(value);
+  return Number.isNaN(rate) ? fallback : rate;
+};
+
 function BookEditForm({
   initialValues,
   initialAuthor,
@@ -199,8 +205,11 @@ export default function BookEdit() {
         isbn10: formValues.isbn10 ?? undefined,
         publicationYear: formValues.publicationYear ?? new Date().getFullYear(),
         publicationMonth: formValues.publicationMonth ?? 1,
-        distributorAuthorRoyaltyRate: formValues.distributorAuthorRoyaltyRate ?? 0.5,
-        handsoldAuthorRoyaltyRate: formValues.handsoldAuthorRoyaltyRate ?? 0.2,
+        distributorAuthorRoyaltyRate: normalizeRoyaltyRate(
+          formValues.distributorAuthorRoyaltyRate,
+          0.5,
+        ),
+        handsoldAuthorRoyaltyRate: normalizeRoyaltyRate(formValues.handsoldAuthorRoyaltyRate, 0.2),
         seriesName: formValues.seriesName ?? undefined,
         seriesPosition: formValues.seriesPosition ?? undefined,
         coverPrice: formValues.coverPrice ?? 0,

--- a/frontend/src/features/books/BookForm.tsx
+++ b/frontend/src/features/books/BookForm.tsx
@@ -22,6 +22,8 @@ import CoverImageField from './CoverImageField';
 
 type BookFormValues = Partial<Omit<BookResponse, 'id' | 'totalSalesToDate'>> & {
   coverImageFile?: File | null;
+  distributorAuthorRoyaltyRate?: number | string | null;
+  handsoldAuthorRoyaltyRate?: number | string | null;
 };
 
 export interface BookFormState {
@@ -107,6 +109,17 @@ export default function BookForm(props: BookFormProps) {
       onFieldChange(
         event.target.name as keyof BookFormState['values'],
         value === '' ? null : Number(value),
+      );
+    },
+    [onFieldChange],
+  );
+
+  const handleRoyaltyFieldChange = React.useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const value = event.target.value;
+      onFieldChange(
+        event.target.name as keyof BookFormState['values'],
+        value === '' ? null : value,
       );
     },
     [onFieldChange],
@@ -278,29 +291,29 @@ export default function BookForm(props: BookFormProps) {
           </Grid>
           <Grid size={{ xs: 12, sm: 6 }} sx={{ display: 'flex' }}>
             <TextField
-              type="number"
+              type="text"
               value={formValues.distributorAuthorRoyaltyRate ?? ''}
-              onChange={handleNumberFieldChange}
+              onChange={handleRoyaltyFieldChange}
               name="distributorAuthorRoyaltyRate"
               label="Distributor Royalty Rate"
               error={!!formErrors.distributorAuthorRoyaltyRate}
               helperText={formErrors.distributorAuthorRoyaltyRate ?? ' '}
               fullWidth
-              inputProps={{ step: '0.01', min: 0, max: 1 }}
+              inputProps={{ inputMode: 'decimal' }}
               onWheel={(e) => (e.target as HTMLElement).blur()}
             />
           </Grid>
           <Grid size={{ xs: 12, sm: 6 }} sx={{ display: 'flex' }}>
             <TextField
-              type="number"
+              type="text"
               value={formValues.handsoldAuthorRoyaltyRate ?? ''}
-              onChange={handleNumberFieldChange}
+              onChange={handleRoyaltyFieldChange}
               name="handsoldAuthorRoyaltyRate"
               label="Handsold Royalty Rate"
               error={!!formErrors.handsoldAuthorRoyaltyRate}
               helperText={formErrors.handsoldAuthorRoyaltyRate ?? ' '}
               fullWidth
-              inputProps={{ step: '0.01', min: 0, max: 1 }}
+              inputProps={{ inputMode: 'decimal' }}
               onWheel={(e) => (e.target as HTMLElement).blur()}
             />
           </Grid>


### PR DESCRIPTION
In the eval session, we discovered that non-number input was accepted for royalty values when editing/creating book. I made it so that now you can type in anything (always the case), but no longer accepted and will not let you submit form. Error message shows up.

Closes #164 