### PR TITLE
feat: currency conversion service (Def 29, Req 3.7)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,6 @@ DB_PASSWORD=your_secure_password_here
 ADMIN_PASSWORD=admin
 JWT_SECRET=change-this-to-a-secure-random-string
 JWT_EXPIRATION_HOURS=24
+
+# Currency conversion (Open Exchange Rates)
+CURRENCY_API_APP_ID=your-open-exchange-rates-app-id

--- a/backend/src/main/java/edu/duke/bookpublishing/currency/CurrencyService.java
+++ b/backend/src/main/java/edu/duke/bookpublishing/currency/CurrencyService.java
@@ -1,0 +1,70 @@
+package edu.duke.bookpublishing.currency;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Pattern;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CurrencyService {
+
+  private static final Pattern CURRENCY_CODE_PATTERN = Pattern.compile("^[A-Z]{3}$");
+  private static final Duration RATE_TTL = Duration.ofHours(24);
+
+  private final OpenExchangeRatesClient openExchangeRatesClient;
+
+  private final ConcurrentHashMap<String, CachedRate> rateCache = new ConcurrentHashMap<>();
+  private volatile Map<String, String> currencyMap;
+
+  record CachedRate(BigDecimal rate, Instant fetchedAt) {
+    boolean isExpired() {
+      return Duration.between(fetchedAt, Instant.now()).compareTo(RATE_TTL) > 0;
+    }
+  }
+
+  public boolean isValidCurrencyCode(String code) {
+    if (code == null || !CURRENCY_CODE_PATTERN.matcher(code).matches()) {
+      return false;
+    }
+    return getSupportedCurrencies().containsKey(code);
+  }
+
+  public BigDecimal convert(String from, String to, BigDecimal amount) {
+    if (from.equals(to)) {
+      return amount;
+    }
+    if (!isValidCurrencyCode(from)) {
+      throw new IllegalArgumentException("Invalid currency code: " + from);
+    }
+    if (!isValidCurrencyCode(to)) {
+      throw new IllegalArgumentException("Invalid currency code: " + to);
+    }
+
+    BigDecimal rate = getCachedRate(from, to);
+    return amount.multiply(rate).setScale(2, RoundingMode.HALF_UP);
+  }
+
+  public Map<String, String> getSupportedCurrencies() {
+    if (currencyMap == null) {
+      currencyMap = openExchangeRatesClient.fetchCurrencies();
+    }
+    return currencyMap;
+  }
+
+  private BigDecimal getCachedRate(String from, String to) {
+    String key = from + "->" + to;
+    CachedRate cached = rateCache.get(key);
+    if (cached != null && !cached.isExpired()) {
+      return cached.rate();
+    }
+    BigDecimal rate = openExchangeRatesClient.fetchRate(from, to);
+    rateCache.put(key, new CachedRate(rate, Instant.now()));
+    return rate;
+  }
+}

--- a/backend/src/main/java/edu/duke/bookpublishing/currency/OpenExchangeRatesClient.java
+++ b/backend/src/main/java/edu/duke/bookpublishing/currency/OpenExchangeRatesClient.java
@@ -1,0 +1,119 @@
+package edu.duke.bookpublishing.currency;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class OpenExchangeRatesClient {
+
+  private static final Logger logger = LoggerFactory.getLogger(OpenExchangeRatesClient.class);
+
+  private final ObjectMapper objectMapper;
+
+  @Value("${app.currency.api-base-url:https://openexchangerates.org/api}")
+  private String baseUrl;
+
+  @Value("${app.currency.api-app-id}")
+  private String appId;
+
+  private final HttpClient httpClient =
+      HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(5)).build();
+
+  public Map<String, String> fetchCurrencies() {
+    String url = baseUrl + "/currencies.json?app_id=" + appId;
+
+    HttpRequest request =
+        HttpRequest.newBuilder(URI.create(url)).timeout(Duration.ofSeconds(8)).GET().build();
+
+    try {
+      HttpResponse<String> response =
+          httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+      if (response.statusCode() >= 400) {
+        logger.warn("Open Exchange Rates API error: HTTP {} for {}", response.statusCode(), url);
+        throw new IllegalStateException(
+            "Open Exchange Rates API error: HTTP " + response.statusCode());
+      }
+      return objectMapper.readValue(response.body(), new TypeReference<>() {});
+    } catch (InterruptedException ex) {
+      Thread.currentThread().interrupt();
+      throw new IllegalStateException("Open Exchange Rates API request interrupted", ex);
+    } catch (IOException ex) {
+      logger.warn("Open Exchange Rates API request failed for {}: {}", url, ex.getMessage());
+      throw new IllegalStateException("Open Exchange Rates API request failed", ex);
+    }
+  }
+
+  /**
+   * Fetches the exchange rate from one currency to another. Free tier is base-locked to USD, so we
+   * fetch USD-based rates and compute the cross rate: rate(FROM→TO) = rate(USD→TO) / rate(USD→FROM)
+   */
+  public BigDecimal fetchRate(String from, String to) {
+    String url = baseUrl + "/latest.json?app_id=" + appId;
+
+    HttpRequest request =
+        HttpRequest.newBuilder(URI.create(url)).timeout(Duration.ofSeconds(8)).GET().build();
+
+    try {
+      HttpResponse<String> response =
+          httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+      if (response.statusCode() == 404) {
+        throw new IllegalArgumentException("Unknown currency code: " + from + " or " + to);
+      }
+      if (response.statusCode() >= 400) {
+        logger.warn("Open Exchange Rates API error: HTTP {} for {}", response.statusCode(), url);
+        throw new IllegalStateException(
+            "Open Exchange Rates API error: HTTP " + response.statusCode());
+      }
+      JsonNode root = objectMapper.readTree(response.body());
+      JsonNode rates = root.path("rates");
+
+      if ("USD".equals(from)) {
+        JsonNode toRate = rates.path(to);
+        if (toRate.isMissingNode()) {
+          throw new IllegalArgumentException("Unknown currency code: " + to);
+        }
+        return toRate.decimalValue();
+      }
+
+      if ("USD".equals(to)) {
+        JsonNode fromRate = rates.path(from);
+        if (fromRate.isMissingNode()) {
+          throw new IllegalArgumentException("Unknown currency code: " + from);
+        }
+        return BigDecimal.ONE.divide(fromRate.decimalValue(), 10, RoundingMode.HALF_UP);
+      }
+
+      JsonNode fromRate = rates.path(from);
+      JsonNode toRate = rates.path(to);
+      if (fromRate.isMissingNode()) {
+        throw new IllegalArgumentException("Unknown currency code: " + from);
+      }
+      if (toRate.isMissingNode()) {
+        throw new IllegalArgumentException("Unknown currency code: " + to);
+      }
+      return toRate.decimalValue().divide(fromRate.decimalValue(), 10, RoundingMode.HALF_UP);
+    } catch (InterruptedException ex) {
+      Thread.currentThread().interrupt();
+      throw new IllegalStateException("Open Exchange Rates API request interrupted", ex);
+    } catch (IOException ex) {
+      logger.warn("Open Exchange Rates API request failed for {}: {}", url, ex.getMessage());
+      throw new IllegalStateException("Open Exchange Rates API request failed", ex);
+    }
+  }
+}

--- a/backend/src/main/java/edu/duke/bookpublishing/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/edu/duke/bookpublishing/exception/GlobalExceptionHandler.java
@@ -59,6 +59,11 @@ public class GlobalExceptionHandler {
     return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Map.of("error", ex.getMessage()));
   }
 
+  @ExceptionHandler(IllegalArgumentException.class)
+  public ResponseEntity<Map<String, String>> handleIllegalArgument(IllegalArgumentException ex) {
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Map.of("error", ex.getMessage()));
+  }
+
   @ExceptionHandler(IllegalStateException.class)
   public ResponseEntity<Map<String, String>> handleIllegalState(IllegalStateException ex) {
     return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -11,6 +11,8 @@ app.cookie-secure=${COOKIE_SECURE:false}
 
 # External integrations
 app.openlibrary.user-agent=${OPENLIBRARY_USER_AGENT:book-publishing/1.0}
+app.currency.api-base-url=${CURRENCY_API_BASE_URL:https://openexchangerates.org/api}
+app.currency.api-app-id=${CURRENCY_API_APP_ID}
 
 # Cover image thumbnails
 app.covers.thumbnail-width=200

--- a/backend/src/test/java/edu/duke/bookpublishing/currency/CurrencyServiceTest.java
+++ b/backend/src/test/java/edu/duke/bookpublishing/currency/CurrencyServiceTest.java
@@ -1,0 +1,128 @@
+package edu.duke.bookpublishing.currency;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.math.BigDecimal;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class CurrencyServiceTest {
+
+  private OpenExchangeRatesClient openExchangeRatesClient;
+  private CurrencyService currencyService;
+
+  private static final Map<String, String> CURRENCIES =
+      Map.of("USD", "United States Dollar", "GBP", "British Pound", "EUR", "Euro");
+
+  @BeforeEach
+  void setUp() {
+    openExchangeRatesClient = mock(OpenExchangeRatesClient.class);
+    currencyService = new CurrencyService(openExchangeRatesClient);
+  }
+
+  @Test
+  void sameCurrencyReturnsAmountUnchanged() {
+    BigDecimal result = currencyService.convert("USD", "USD", new BigDecimal("100.00"));
+
+    assertEquals(new BigDecimal("100.00"), result);
+    verifyNoInteractions(openExchangeRatesClient);
+  }
+
+  @Test
+  void multipliesByRateAndRoundsToTwoDecimalPlaces() {
+    when(openExchangeRatesClient.fetchCurrencies()).thenReturn(CURRENCIES);
+    when(openExchangeRatesClient.fetchRate("GBP", "USD")).thenReturn(new BigDecimal("1.33"));
+
+    BigDecimal result = currencyService.convert("GBP", "USD", new BigDecimal("10.00"));
+
+    assertEquals(new BigDecimal("13.30"), result);
+  }
+
+  @Test
+  void roundsHalfUp() {
+    when(openExchangeRatesClient.fetchCurrencies()).thenReturn(CURRENCIES);
+    when(openExchangeRatesClient.fetchRate("GBP", "USD")).thenReturn(new BigDecimal("1.3333"));
+
+    BigDecimal result = currencyService.convert("GBP", "USD", new BigDecimal("10.00"));
+
+    assertEquals(new BigDecimal("13.33"), result);
+  }
+
+  @Test
+  void throwsForInvalidFromCurrency() {
+    when(openExchangeRatesClient.fetchCurrencies()).thenReturn(CURRENCIES);
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> currencyService.convert("XYZ", "USD", BigDecimal.TEN));
+  }
+
+  @Test
+  void throwsForInvalidToCurrency() {
+    when(openExchangeRatesClient.fetchCurrencies()).thenReturn(CURRENCIES);
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> currencyService.convert("USD", "XYZ", BigDecimal.TEN));
+  }
+
+  @Test
+  void validatesKnownCurrencyCode() {
+    when(openExchangeRatesClient.fetchCurrencies()).thenReturn(CURRENCIES);
+
+    assertTrue(currencyService.isValidCurrencyCode("USD"));
+    assertTrue(currencyService.isValidCurrencyCode("GBP"));
+    assertTrue(currencyService.isValidCurrencyCode("EUR"));
+  }
+
+  @Test
+  void rejectsUnknownCurrencyCode() {
+    when(openExchangeRatesClient.fetchCurrencies()).thenReturn(CURRENCIES);
+
+    assertFalse(currencyService.isValidCurrencyCode("XYZ"));
+  }
+
+  @Test
+  void rejectsNullCurrencyCode() {
+    assertFalse(currencyService.isValidCurrencyCode(null));
+  }
+
+  @Test
+  void rejectsEmptyCurrencyCode() {
+    assertFalse(currencyService.isValidCurrencyCode(""));
+  }
+
+  @Test
+  void rejectsWrongLengthCurrencyCode() {
+    assertFalse(currencyService.isValidCurrencyCode("US"));
+    assertFalse(currencyService.isValidCurrencyCode("USDX"));
+  }
+
+  @Test
+  void rejectsLowercaseCurrencyCode() {
+    assertFalse(currencyService.isValidCurrencyCode("usd"));
+  }
+
+  @Test
+  void cachesRatesAcrossConvertCalls() {
+    when(openExchangeRatesClient.fetchCurrencies()).thenReturn(CURRENCIES);
+    when(openExchangeRatesClient.fetchRate("GBP", "USD")).thenReturn(new BigDecimal("1.33"));
+
+    currencyService.convert("GBP", "USD", new BigDecimal("10.00"));
+    currencyService.convert("GBP", "USD", new BigDecimal("20.00"));
+
+    verify(openExchangeRatesClient, times(1)).fetchRate("GBP", "USD");
+  }
+
+  @Test
+  void cachesCurrencyListAcrossCalls() {
+    when(openExchangeRatesClient.fetchCurrencies()).thenReturn(CURRENCIES);
+
+    currencyService.getSupportedCurrencies();
+    currencyService.getSupportedCurrencies();
+
+    verify(openExchangeRatesClient, times(1)).fetchCurrencies();
+  }
+}

--- a/backend/src/test/resources/application-test.properties
+++ b/backend/src/test/resources/application-test.properties
@@ -7,3 +7,6 @@ spring.datasource.password=
 # JPA
 spring.jpa.hibernate.ddl-auto=create-drop
 spring.jpa.show-sql=false
+
+# Currency API (dummy value — integration tests don't call the real API)
+app.currency.api-app-id=test-dummy-key

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - JWT_SECRET=${JWT_SECRET:-change-this-in-production}
       - JWT_EXPIRATION_HOURS=${JWT_EXPIRATION_HOURS:-24}
       - ADMIN_PASSWORD=${ADMIN_PASSWORD:-admin}
+      - CURRENCY_API_APP_ID=${CURRENCY_API_APP_ID}
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
## Related Issues
Partially addresses Ev3 currency requirements — this PR builds the service layer only.
Depends on #188 / #189 for Sale entity wiring.

## Summary
Ev3 Req 3.7 requires converting foreign-currency publisher revenue to USD using a third-party currency conversion system (Def 29). This PR adds the backend service infrastructure for that conversion.

We chose **Open Exchange Rates** (`openexchangerates.org`) over the originally planned Frankfurter API because Frankfurter (ECB data) is missing three Amazon marketplace currencies required by our variance: EGP (Egypt), SAR (Saudi Arabia), and AED (UAE). Open Exchange Rates covers all 17 currencies in Daniel's Currency enum with 173 total.

The free tier is base-locked to USD, so the client computes cross rates (e.g., GBP→EUR = USD→EUR / USD→GBP). This is transparent to callers.

## Files Changed
- **`OpenExchangeRatesClient.java`** (new) — HTTP client wrapping the Open Exchange Rates API. Fetches supported currencies and exchange rates. Mirrors the `OpenLibraryClient` pattern (HttpClient, ObjectMapper, @Value config, same error handling).
- **`CurrencyService.java`** (new) — `isValidCurrencyCode()`, `convert()`, `getSupportedCurrencies()`. Caches rates for 24h in a ConcurrentHashMap; currency list fetched once and held in memory.
- **`CurrencyServiceTest.java`** (new) — 12 unit tests with mocked client: same-currency short-circuit, rate multiplication and rounding, invalid code rejection (null/empty/lowercase/unknown), cache verification.
- **`GlobalExceptionHandler.java`** — Added `IllegalArgumentException` → 400 handler. Also fixes an existing bug where invalid ISBN lookups (which throw `IllegalArgumentException`) returned 500 instead of 400.
- **`application.properties`** — Added `app.currency.api-base-url` and `app.currency.api-app-id` (no hardcoded key).
- **`application-test.properties`** — Dummy API key so integration tests don't need the real one.
- **`docker-compose.yml`** — Passes `CURRENCY_API_APP_ID` env var to backend container.
- **`.env.example`** — Documents the new env var for other developers.

## Technical Decisions
- **Open Exchange Rates over Frankfurter**: Frankfurter uses ECB data which doesn't include EGP, SAR, or AED — three currencies in Daniel's enum based on the Amazon marketplace variance. Open Exchange Rates covers all of them.
- **API key as env var**: Follows the existing `JWT_SECRET` pattern — stored in `.env` (gitignored), passed through docker-compose, with `application.properties` requiring it (no default, fails fast if missing).
- **Cross-rate computation in client**: Free tier locks base to USD. Rather than paying for a higher tier, we fetch USD rates and divide. Precision is maintained at scale 10 before the service rounds to 2 decimal places.
- **No REST endpoints**: Deferred to the PR that wires currency into SaleService. This PR is service-layer only.

## Test Plan
- [x] `just check` passes (format, lint, all backend + frontend tests)
- [x] All 12 new CurrencyServiceTest cases pass
- [x] No existing tests broken by GlobalExceptionHandler change
- [x] Verified Open Exchange Rates API returns rates for all 17 enum currencies (AUD, BRL, CAD, CNY, EGP, EUR, GBP, INR, JPY, MXN, PLN, SAR, SGD, SEK, TRY, AED, USD)