### PR TITLE
SalesList Frontend (#1)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4629,9 +4629,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },

--- a/frontend/src/features/sales/SaleList.tsx
+++ b/frontend/src/features/sales/SaleList.tsx
@@ -405,3 +405,449 @@ export default function SaleList() {
     </PageContainer>
   );
 }
+
+// import AddIcon from '@mui/icons-material/Add';
+// import CommentIcon from '@mui/icons-material/Comment';
+// import DeleteIcon from '@mui/icons-material/Delete';
+// import RefreshIcon from '@mui/icons-material/Refresh';
+// import UploadFileIcon from '@mui/icons-material/UploadFile';
+// import Autocomplete from '@mui/material/Autocomplete';
+// import Box from '@mui/material/Box';
+// import Button from '@mui/material/Button';
+// import FormControl from '@mui/material/FormControl';
+// import IconButton from '@mui/material/IconButton';
+// import InputLabel from '@mui/material/InputLabel';
+// import MenuItem from '@mui/material/MenuItem';
+// import Select, { type SelectChangeEvent } from '@mui/material/Select';
+// import Stack from '@mui/material/Stack';
+// import TextField from '@mui/material/TextField';
+// import Tooltip from '@mui/material/Tooltip';
+
+// import { type AuthorResponse, AuthorsService, type SaleResponse, SalesService } from '@/api';
+// import PageContainer from '@/components/PageContainer';
+// import PaidStatusChip from '@/components/PaidStatusChip';
+// import StandardDataGrid from '@/components/StandardDataGrid';
+// import { useDialogs } from '@/hooks/useDialogs/useDialogs';
+// import { useNotifications } from '@/hooks/useNotifications/useNotifications';
+// import { useServerDataGrid } from '@/hooks/useServerDataGrid';
+// import { getErrorMessage } from '@/utils/error';
+// import { formatCurrency, formatCurrencyWithCode, formatMonthYear } from '@/utils/formatting';
+// import {
+//   GridActionsCellItem,
+//   type GridColDef,
+//   type GridEventListener,
+//   type GridSortModel,
+// } from '@mui/x-data-grid';
+// import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
+// import { DatePicker } from '@mui/x-date-pickers/DatePicker';
+// import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+// import dayjs, { type Dayjs } from 'dayjs';
+// import * as React from 'react';
+// import { Link, useNavigate } from 'react-router-dom';
+
+// export default function SaleList() {
+//   const navigate = useNavigate();
+//   const dialogs = useDialogs();
+//   const notifications = useNotifications();
+
+//   // Default sort: descending by date (newest first) - requirement 3.1.1
+//   const [sortModel, setSortModel] = React.useState<GridSortModel>([
+//     { field: 'saleYear', sort: 'desc' },
+//   ]);
+
+//   const [startDate, setStartDate] = React.useState<Dayjs | null>(null);
+//   const [endDate, setEndDate] = React.useState<Dayjs | null>(null);
+//   const [selectedAuthor, setSelectedAuthor] = React.useState<AuthorResponse | null>(null);
+//   const [saleSource, setSaleSource] = React.useState<string>('all');
+//   const [authors, setAuthors] = React.useState<AuthorResponse[]>([]);
+
+//   const fetchFn = React.useCallback(
+//     async (params: { page: number; pageSize: number; showAll: boolean }) => {
+//       const sortFields = sortModel?.map((col) => col.field);
+//       const sortDirections = sortModel?.map((col) => col.sort ?? 'desc');
+
+//       // Date range filter - requirement 3.1.2
+//       const startDateParam = startDate
+//         ? startDate.startOf('month').format('YYYY-MM-DD')
+//         : undefined;
+//       const endDateParam = endDate ? endDate.endOf('month').format('YYYY-MM-DD') : undefined;
+
+//       // Author and sale source filters - requirement 3.1.2
+//       const authorIdParam = selectedAuthor?.id;
+//       const saleSourceParam = saleSource === 'all' ? undefined : saleSource.toUpperCase();
+
+//       return SalesService.getSales(
+//         params.page,
+//         params.pageSize,
+//         params.showAll,
+//         sortFields,
+//         sortDirections,
+//         startDateParam,
+//         endDateParam,
+//         authorIdParam,
+//         saleSourceParam,
+//       );
+//     },
+//     [sortModel, startDate, endDate, selectedAuthor, saleSource],
+//   );
+
+//   const {
+//     rows,
+//     rowCount,
+//     isLoading,
+//     error,
+//     paginationModel,
+//     onPaginationModelChange,
+//     refresh,
+//     setIsLoading,
+//   } = useServerDataGrid<SaleResponse>({ fetchFn });
+
+//   const loadAuthors = React.useCallback(async () => {
+//     try {
+//       const response = await AuthorsService.getAllAuthors(0, 1000, true);
+//       setAuthors(response.content ?? []);
+//     } catch {
+//       // silent — empty author filter is acceptable
+//     }
+//   }, []);
+
+//   React.useEffect(() => {
+//     loadAuthors();
+//   }, [loadAuthors]);
+
+//   // Requirement 3.1.3 - Navigate to detail/modify view
+//   const handleRowClick = React.useCallback<GridEventListener<'rowClick'>>(
+//     ({ row }) => navigate(`/sales/${row.id}`),
+//     [navigate],
+//   );
+
+//   // Requirement 3.1.4 - Navigate to sales input tool
+//   const handleCreateClick = React.useCallback(() => navigate('/sales/new'), [navigate]);
+
+//   const handleImportClick = React.useCallback(() => navigate('/sales/import'), [navigate]);
+
+//   const handleRowDelete = React.useCallback(
+//     (sale: SaleResponse) => async () => {
+//       const confirmed = await dialogs.confirm(
+//         `Do you wish to delete this sale record for ${sale.bookTitle || 'this book'}?`,
+//         {
+//           title: 'Delete sale record?',
+//           severity: 'error',
+//           okText: 'Delete',
+//           cancelText: 'Cancel',
+//         },
+//       );
+
+//       if (confirmed) {
+//         setIsLoading(true);
+//         try {
+//           await SalesService.deleteSale(Number(sale.id));
+//           notifications.show('Sale record deleted successfully.', {
+//             severity: 'success',
+//             autoHideDuration: 3000,
+//           });
+//           refresh();
+//         } catch (deleteError) {
+//           notifications.show(
+//             `Failed to delete sale record. Reason: ${getErrorMessage(deleteError)}`,
+//             {
+//               severity: 'error',
+//               autoHideDuration: 3000,
+//             },
+//           );
+//         }
+//         setIsLoading(false);
+//       }
+//     },
+//     [dialogs, notifications, refresh, setIsLoading],
+//   );
+
+//   const columns = React.useMemo<GridColDef<SaleResponse>[]>(
+//     () => [
+//       {
+//         field: 'bookTitle',
+//         headerName: 'Book Title',
+//         flex: 1.5,
+//         minWidth: 170,
+//         renderCell: (params) => {
+//           const bookId = params.row.bookId;
+//           const title = params.row.bookTitle;
+
+//           return (
+//             <Link
+//               to={`/books/${bookId}`}
+//               style={{
+//                 color: 'inherit',
+//                 textDecoration: 'none',
+//               }}
+//               onMouseEnter={(e) => {
+//                 e.currentTarget.style.textDecoration = 'underline';
+//               }}
+//               onMouseLeave={(e) => {
+//                 e.currentTarget.style.textDecoration = 'none';
+//               }}
+//               onClick={(e) => {
+//                 e.stopPropagation();
+//               }}
+//             >
+//               {title}
+//             </Link>
+//           );
+//         },
+//       },
+//       {
+//         field: 'bookAuthor',
+//         headerName: 'Author',
+//         flex: 1.2,
+//         minWidth: 140,
+//       },
+//       {
+//         field: 'saleSource',
+//         headerName: 'Sale Source',
+//         flex: 1,
+//         minWidth: 120,
+//         valueGetter: (_value, row) => {
+//           if (row.saleSource === 'DISTRIBUTOR') return 'Distributor';
+//           if (row.saleSource === 'HAND_SOLD') return 'Hand Sold';
+//           return row.saleSource;
+//         },
+//       },
+//       {
+//         field: 'distributor',
+//         headerName: 'Distributor',
+//         flex: 1,
+//         minWidth: 130,
+//         valueGetter: (_value, row) => {
+//           if (row.distributor === 'INGRAM_SPARK') return 'Ingram Spark';
+//           if (row.distributor === 'AMAZON') return 'Amazon';
+//           if (row.distributor === 'OTHER') return 'Other';
+//           return row.distributor;
+//         },
+//       },
+//       {
+//         field: 'format',
+//         headerName: 'Format',
+//         flex: 0.9,
+//         minWidth: 110,
+//         valueGetter: (_value, row) => {
+//           if (row.format === 'PRINT') return 'Print';
+//           if (row.format === 'EBOOK') return 'Ebook';
+//           if (row.format === 'KINDLE_UNLIMITED') return 'Kindle Unlimited';
+//           return row.format;
+//         },
+//       },
+//       {
+//         field: 'saleYear',
+//         headerName: 'Date',
+//         flex: 1,
+//         minWidth: 120,
+//         valueGetter: (_value, row) => formatMonthYear(row.saleMonth, row.saleYear),
+//       },
+//       {
+//         field: 'quantitySold',
+//         headerName: 'Qty / KENP',
+//         type: 'number',
+//         flex: 0.8,
+//         minWidth: 90,
+//         valueGetter: (_value, row) =>
+//           row.format === 'KINDLE_UNLIMITED' ? row.kenp : row.quantitySold,
+//       },
+//       {
+//         field: 'originalPublisherRevenue',
+//         headerName: 'Revenue (Original)',
+//         type: 'number',
+//         flex: 1,
+//         minWidth: 150,
+//         renderCell: (params) =>
+//           formatCurrencyWithCode(
+//             Number(params.row.originalPublisherRevenue),
+//             params.row.saleCurrency,
+//           ),
+//       },
+//       {
+//         field: 'publisherRevenue',
+//         headerName: 'Revenue (USD)',
+//         type: 'number',
+//         flex: 1,
+//         minWidth: 120,
+//         valueFormatter: (value) => formatCurrency(Number(value)),
+//       },
+//       {
+//         field: 'authorRoyalty',
+//         headerName: 'Royalty',
+//         type: 'number',
+//         flex: 1,
+//         minWidth: 120,
+//         valueFormatter: (value) => formatCurrency(Number(value)),
+//       },
+//       {
+//         field: 'comment',
+//         headerName: 'Comment',
+//         width: 90,
+//         sortable: false,
+//         filterable: false,
+//         align: 'center',
+//         headerAlign: 'center',
+//         renderCell: (params) => {
+//           const comment = params.row.comment;
+
+//           if (!comment) return null;
+
+//           return (
+//             <Tooltip title={comment} placement="top" enterDelay={300}>
+//               <IconButton
+//                 size="small"
+//                 onClick={(e) => e.stopPropagation()}
+//                 aria-label="View comment"
+//               >
+//                 <CommentIcon fontSize="small" />
+//               </IconButton>
+//             </Tooltip>
+//           );
+//         },
+//       },
+//       {
+//         field: 'hasAuthorBeenPaid',
+//         headerName: 'Paid',
+//         flex: 1,
+//         minWidth: 120,
+//         align: 'left',
+//         headerAlign: 'center',
+//         renderCell: (params) => (
+//           <Box sx={{ pl: 1.5 }}>
+//             <PaidStatusChip paid={params.row.hasAuthorBeenPaid} />
+//           </Box>
+//         ),
+//       },
+//       {
+//         field: 'actions',
+//         type: 'actions',
+//         width: 45,
+//         align: 'right',
+//         getActions: ({ row }) => [
+//           <GridActionsCellItem
+//             key="delete-item"
+//             icon={<DeleteIcon />}
+//             label="Delete"
+//             onClick={handleRowDelete(row)}
+//           />,
+//         ],
+//       },
+//     ],
+//     [handleRowDelete],
+//   );
+
+//   const pageTitle = 'Records';
+
+//   return (
+//     <PageContainer
+//       maxWidth="xl"
+//       title={pageTitle}
+//       breadcrumbs={[{ title: pageTitle }]}
+//       actions={
+//         <Stack direction="row" alignItems="center" spacing={1} flexWrap="wrap" useFlexGap>
+//           <Tooltip title="Reload data" placement="bottom" enterDelay={1000}>
+//             <div>
+//               <IconButton size="small" aria-label="refresh" onClick={refresh}>
+//                 <RefreshIcon />
+//               </IconButton>
+//             </div>
+//           </Tooltip>
+
+//           <LocalizationProvider dateAdapter={AdapterDayjs}>
+//             <DatePicker
+//               label="Start"
+//               value={startDate}
+//               onChange={(v) => setStartDate(v)}
+//               views={['year', 'month']}
+//               format="MM/YYYY"
+//               openTo="year"
+//               minDate={dayjs('1900-01-01')}
+//               maxDate={dayjs()}
+//               slotProps={{
+//                 textField: {
+//                   size: 'small',
+//                   placeholder: 'MM/YYYY',
+//                   InputLabelProps: { shrink: true },
+//                 },
+//                 toolbar: { hidden: true },
+//                 field: {
+//                   clearable: true,
+//                 },
+//               }}
+//               sx={{ width: 160 }}
+//             />
+//             <DatePicker
+//               label="End"
+//               value={endDate}
+//               onChange={(v) => setEndDate(v)}
+//               views={['year', 'month']}
+//               format="MM/YYYY"
+//               openTo="year"
+//               minDate={dayjs('1900-01-01')}
+//               maxDate={dayjs()}
+//               slotProps={{
+//                 textField: {
+//                   size: 'small',
+//                   placeholder: 'MM/YYYY',
+//                   InputLabelProps: { shrink: true },
+//                 },
+//                 toolbar: { hidden: true },
+//                 field: {
+//                   clearable: true,
+//                 },
+//               }}
+//               sx={{ width: 160 }}
+//             />
+//           </LocalizationProvider>
+
+//           <Autocomplete
+//             options={authors}
+//             getOptionLabel={(author) => author.name}
+//             renderInput={(params) => (
+//               <TextField {...params} label="Author" size="small" placeholder="All Authors" />
+//             )}
+//             value={selectedAuthor}
+//             onChange={(_, newValue) => setSelectedAuthor(newValue)}
+//             sx={{ minWidth: 200 }}
+//           />
+
+//           <FormControl size="small" sx={{ minWidth: 150 }}>
+//             <InputLabel>Sale Source</InputLabel>
+//             <Select
+//               value={saleSource}
+//               label="Sale Source"
+//               onChange={(e: SelectChangeEvent) => setSaleSource(e.target.value)}
+//             >
+//               <MenuItem value="all">All</MenuItem>
+//               <MenuItem value="distributor">Distributor</MenuItem>
+//               <MenuItem value="hand_sold">Hand Sold</MenuItem>
+//             </Select>
+//           </FormControl>
+
+//           <Button variant="contained" onClick={handleCreateClick} startIcon={<AddIcon />}>
+//             New Sale
+//           </Button>
+//           <Button variant="outlined" onClick={handleImportClick} startIcon={<UploadFileIcon />}>
+//             Import CSV
+//           </Button>
+//         </Stack>
+//       }
+//     >
+//       <Box sx={{ flex: 1, width: '100%' }}>
+//         <StandardDataGrid
+//           rows={rows}
+//           rowCount={rowCount}
+//           columns={columns}
+//           error={error}
+//           onRowClick={handleRowClick}
+//           loading={isLoading}
+//           paginationModel={paginationModel}
+//           onPaginationModelChange={onPaginationModelChange}
+//           sortModel={sortModel}
+//           onSortModelChange={setSortModel}
+//         />
+//       </Box>
+//     </PageContainer>
+//   );
+// }

--- a/frontend/src/features/sales/SaleList.tsx
+++ b/frontend/src/features/sales/SaleList.tsx
@@ -23,7 +23,7 @@ import { useDialogs } from '@/hooks/useDialogs/useDialogs';
 import { useNotifications } from '@/hooks/useNotifications/useNotifications';
 import { useServerDataGrid } from '@/hooks/useServerDataGrid';
 import { getErrorMessage } from '@/utils/error';
-import { formatCurrency, formatMonthYear } from '@/utils/formatting';
+import { formatCurrency, formatCurrencyWithCode, formatMonthYear } from '@/utils/formatting';
 import {
   GridActionsCellItem,
   type GridColDef,
@@ -205,6 +205,30 @@ export default function SaleList() {
         },
       },
       {
+        field: 'distributor',
+        headerName: 'Distributor',
+        flex: 1,
+        minWidth: 130,
+        valueGetter: (_value, row) => {
+          if (row.distributor === 'INGRAM_SPARK') return 'Ingram Spark';
+          if (row.distributor === 'AMAZON') return 'Amazon';
+          if (row.distributor === 'OTHER') return 'Other';
+          return row.distributor;
+        },
+      },
+      {
+        field: 'format',
+        headerName: 'Format',
+        flex: 0.9,
+        minWidth: 110,
+        valueGetter: (_value, row) => {
+          if (row.format === 'PRINT') return 'Print';
+          if (row.format === 'EBOOK') return 'Ebook';
+          if (row.format === 'KINDLE_UNLIMITED') return 'Kindle Unlimited';
+          return row.format;
+        },
+      },
+      {
         field: 'saleYear',
         headerName: 'Date',
         flex: 1,
@@ -213,14 +237,28 @@ export default function SaleList() {
       },
       {
         field: 'quantitySold',
-        headerName: 'Qty',
+        headerName: 'Qty / KENP',
         type: 'number',
         flex: 0.8,
         minWidth: 90,
+        valueGetter: (_value, row) =>
+          row.format === 'KINDLE_UNLIMITED' ? row.kenp : row.quantitySold,
+      },
+      {
+        field: 'originalPublisherRevenue',
+        headerName: 'Revenue (Original)',
+        type: 'number',
+        flex: 1,
+        minWidth: 150,
+        renderCell: (params) =>
+          formatCurrencyWithCode(
+            Number(params.row.originalPublisherRevenue),
+            params.row.saleCurrency,
+          ),
       },
       {
         field: 'publisherRevenue',
-        headerName: 'Revenue',
+        headerName: 'Revenue (USD)',
         type: 'number',
         flex: 1,
         minWidth: 120,
@@ -405,449 +443,3 @@ export default function SaleList() {
     </PageContainer>
   );
 }
-
-// import AddIcon from '@mui/icons-material/Add';
-// import CommentIcon from '@mui/icons-material/Comment';
-// import DeleteIcon from '@mui/icons-material/Delete';
-// import RefreshIcon from '@mui/icons-material/Refresh';
-// import UploadFileIcon from '@mui/icons-material/UploadFile';
-// import Autocomplete from '@mui/material/Autocomplete';
-// import Box from '@mui/material/Box';
-// import Button from '@mui/material/Button';
-// import FormControl from '@mui/material/FormControl';
-// import IconButton from '@mui/material/IconButton';
-// import InputLabel from '@mui/material/InputLabel';
-// import MenuItem from '@mui/material/MenuItem';
-// import Select, { type SelectChangeEvent } from '@mui/material/Select';
-// import Stack from '@mui/material/Stack';
-// import TextField from '@mui/material/TextField';
-// import Tooltip from '@mui/material/Tooltip';
-
-// import { type AuthorResponse, AuthorsService, type SaleResponse, SalesService } from '@/api';
-// import PageContainer from '@/components/PageContainer';
-// import PaidStatusChip from '@/components/PaidStatusChip';
-// import StandardDataGrid from '@/components/StandardDataGrid';
-// import { useDialogs } from '@/hooks/useDialogs/useDialogs';
-// import { useNotifications } from '@/hooks/useNotifications/useNotifications';
-// import { useServerDataGrid } from '@/hooks/useServerDataGrid';
-// import { getErrorMessage } from '@/utils/error';
-// import { formatCurrency, formatCurrencyWithCode, formatMonthYear } from '@/utils/formatting';
-// import {
-//   GridActionsCellItem,
-//   type GridColDef,
-//   type GridEventListener,
-//   type GridSortModel,
-// } from '@mui/x-data-grid';
-// import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
-// import { DatePicker } from '@mui/x-date-pickers/DatePicker';
-// import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
-// import dayjs, { type Dayjs } from 'dayjs';
-// import * as React from 'react';
-// import { Link, useNavigate } from 'react-router-dom';
-
-// export default function SaleList() {
-//   const navigate = useNavigate();
-//   const dialogs = useDialogs();
-//   const notifications = useNotifications();
-
-//   // Default sort: descending by date (newest first) - requirement 3.1.1
-//   const [sortModel, setSortModel] = React.useState<GridSortModel>([
-//     { field: 'saleYear', sort: 'desc' },
-//   ]);
-
-//   const [startDate, setStartDate] = React.useState<Dayjs | null>(null);
-//   const [endDate, setEndDate] = React.useState<Dayjs | null>(null);
-//   const [selectedAuthor, setSelectedAuthor] = React.useState<AuthorResponse | null>(null);
-//   const [saleSource, setSaleSource] = React.useState<string>('all');
-//   const [authors, setAuthors] = React.useState<AuthorResponse[]>([]);
-
-//   const fetchFn = React.useCallback(
-//     async (params: { page: number; pageSize: number; showAll: boolean }) => {
-//       const sortFields = sortModel?.map((col) => col.field);
-//       const sortDirections = sortModel?.map((col) => col.sort ?? 'desc');
-
-//       // Date range filter - requirement 3.1.2
-//       const startDateParam = startDate
-//         ? startDate.startOf('month').format('YYYY-MM-DD')
-//         : undefined;
-//       const endDateParam = endDate ? endDate.endOf('month').format('YYYY-MM-DD') : undefined;
-
-//       // Author and sale source filters - requirement 3.1.2
-//       const authorIdParam = selectedAuthor?.id;
-//       const saleSourceParam = saleSource === 'all' ? undefined : saleSource.toUpperCase();
-
-//       return SalesService.getSales(
-//         params.page,
-//         params.pageSize,
-//         params.showAll,
-//         sortFields,
-//         sortDirections,
-//         startDateParam,
-//         endDateParam,
-//         authorIdParam,
-//         saleSourceParam,
-//       );
-//     },
-//     [sortModel, startDate, endDate, selectedAuthor, saleSource],
-//   );
-
-//   const {
-//     rows,
-//     rowCount,
-//     isLoading,
-//     error,
-//     paginationModel,
-//     onPaginationModelChange,
-//     refresh,
-//     setIsLoading,
-//   } = useServerDataGrid<SaleResponse>({ fetchFn });
-
-//   const loadAuthors = React.useCallback(async () => {
-//     try {
-//       const response = await AuthorsService.getAllAuthors(0, 1000, true);
-//       setAuthors(response.content ?? []);
-//     } catch {
-//       // silent — empty author filter is acceptable
-//     }
-//   }, []);
-
-//   React.useEffect(() => {
-//     loadAuthors();
-//   }, [loadAuthors]);
-
-//   // Requirement 3.1.3 - Navigate to detail/modify view
-//   const handleRowClick = React.useCallback<GridEventListener<'rowClick'>>(
-//     ({ row }) => navigate(`/sales/${row.id}`),
-//     [navigate],
-//   );
-
-//   // Requirement 3.1.4 - Navigate to sales input tool
-//   const handleCreateClick = React.useCallback(() => navigate('/sales/new'), [navigate]);
-
-//   const handleImportClick = React.useCallback(() => navigate('/sales/import'), [navigate]);
-
-//   const handleRowDelete = React.useCallback(
-//     (sale: SaleResponse) => async () => {
-//       const confirmed = await dialogs.confirm(
-//         `Do you wish to delete this sale record for ${sale.bookTitle || 'this book'}?`,
-//         {
-//           title: 'Delete sale record?',
-//           severity: 'error',
-//           okText: 'Delete',
-//           cancelText: 'Cancel',
-//         },
-//       );
-
-//       if (confirmed) {
-//         setIsLoading(true);
-//         try {
-//           await SalesService.deleteSale(Number(sale.id));
-//           notifications.show('Sale record deleted successfully.', {
-//             severity: 'success',
-//             autoHideDuration: 3000,
-//           });
-//           refresh();
-//         } catch (deleteError) {
-//           notifications.show(
-//             `Failed to delete sale record. Reason: ${getErrorMessage(deleteError)}`,
-//             {
-//               severity: 'error',
-//               autoHideDuration: 3000,
-//             },
-//           );
-//         }
-//         setIsLoading(false);
-//       }
-//     },
-//     [dialogs, notifications, refresh, setIsLoading],
-//   );
-
-//   const columns = React.useMemo<GridColDef<SaleResponse>[]>(
-//     () => [
-//       {
-//         field: 'bookTitle',
-//         headerName: 'Book Title',
-//         flex: 1.5,
-//         minWidth: 170,
-//         renderCell: (params) => {
-//           const bookId = params.row.bookId;
-//           const title = params.row.bookTitle;
-
-//           return (
-//             <Link
-//               to={`/books/${bookId}`}
-//               style={{
-//                 color: 'inherit',
-//                 textDecoration: 'none',
-//               }}
-//               onMouseEnter={(e) => {
-//                 e.currentTarget.style.textDecoration = 'underline';
-//               }}
-//               onMouseLeave={(e) => {
-//                 e.currentTarget.style.textDecoration = 'none';
-//               }}
-//               onClick={(e) => {
-//                 e.stopPropagation();
-//               }}
-//             >
-//               {title}
-//             </Link>
-//           );
-//         },
-//       },
-//       {
-//         field: 'bookAuthor',
-//         headerName: 'Author',
-//         flex: 1.2,
-//         minWidth: 140,
-//       },
-//       {
-//         field: 'saleSource',
-//         headerName: 'Sale Source',
-//         flex: 1,
-//         minWidth: 120,
-//         valueGetter: (_value, row) => {
-//           if (row.saleSource === 'DISTRIBUTOR') return 'Distributor';
-//           if (row.saleSource === 'HAND_SOLD') return 'Hand Sold';
-//           return row.saleSource;
-//         },
-//       },
-//       {
-//         field: 'distributor',
-//         headerName: 'Distributor',
-//         flex: 1,
-//         minWidth: 130,
-//         valueGetter: (_value, row) => {
-//           if (row.distributor === 'INGRAM_SPARK') return 'Ingram Spark';
-//           if (row.distributor === 'AMAZON') return 'Amazon';
-//           if (row.distributor === 'OTHER') return 'Other';
-//           return row.distributor;
-//         },
-//       },
-//       {
-//         field: 'format',
-//         headerName: 'Format',
-//         flex: 0.9,
-//         minWidth: 110,
-//         valueGetter: (_value, row) => {
-//           if (row.format === 'PRINT') return 'Print';
-//           if (row.format === 'EBOOK') return 'Ebook';
-//           if (row.format === 'KINDLE_UNLIMITED') return 'Kindle Unlimited';
-//           return row.format;
-//         },
-//       },
-//       {
-//         field: 'saleYear',
-//         headerName: 'Date',
-//         flex: 1,
-//         minWidth: 120,
-//         valueGetter: (_value, row) => formatMonthYear(row.saleMonth, row.saleYear),
-//       },
-//       {
-//         field: 'quantitySold',
-//         headerName: 'Qty / KENP',
-//         type: 'number',
-//         flex: 0.8,
-//         minWidth: 90,
-//         valueGetter: (_value, row) =>
-//           row.format === 'KINDLE_UNLIMITED' ? row.kenp : row.quantitySold,
-//       },
-//       {
-//         field: 'originalPublisherRevenue',
-//         headerName: 'Revenue (Original)',
-//         type: 'number',
-//         flex: 1,
-//         minWidth: 150,
-//         renderCell: (params) =>
-//           formatCurrencyWithCode(
-//             Number(params.row.originalPublisherRevenue),
-//             params.row.saleCurrency,
-//           ),
-//       },
-//       {
-//         field: 'publisherRevenue',
-//         headerName: 'Revenue (USD)',
-//         type: 'number',
-//         flex: 1,
-//         minWidth: 120,
-//         valueFormatter: (value) => formatCurrency(Number(value)),
-//       },
-//       {
-//         field: 'authorRoyalty',
-//         headerName: 'Royalty',
-//         type: 'number',
-//         flex: 1,
-//         minWidth: 120,
-//         valueFormatter: (value) => formatCurrency(Number(value)),
-//       },
-//       {
-//         field: 'comment',
-//         headerName: 'Comment',
-//         width: 90,
-//         sortable: false,
-//         filterable: false,
-//         align: 'center',
-//         headerAlign: 'center',
-//         renderCell: (params) => {
-//           const comment = params.row.comment;
-
-//           if (!comment) return null;
-
-//           return (
-//             <Tooltip title={comment} placement="top" enterDelay={300}>
-//               <IconButton
-//                 size="small"
-//                 onClick={(e) => e.stopPropagation()}
-//                 aria-label="View comment"
-//               >
-//                 <CommentIcon fontSize="small" />
-//               </IconButton>
-//             </Tooltip>
-//           );
-//         },
-//       },
-//       {
-//         field: 'hasAuthorBeenPaid',
-//         headerName: 'Paid',
-//         flex: 1,
-//         minWidth: 120,
-//         align: 'left',
-//         headerAlign: 'center',
-//         renderCell: (params) => (
-//           <Box sx={{ pl: 1.5 }}>
-//             <PaidStatusChip paid={params.row.hasAuthorBeenPaid} />
-//           </Box>
-//         ),
-//       },
-//       {
-//         field: 'actions',
-//         type: 'actions',
-//         width: 45,
-//         align: 'right',
-//         getActions: ({ row }) => [
-//           <GridActionsCellItem
-//             key="delete-item"
-//             icon={<DeleteIcon />}
-//             label="Delete"
-//             onClick={handleRowDelete(row)}
-//           />,
-//         ],
-//       },
-//     ],
-//     [handleRowDelete],
-//   );
-
-//   const pageTitle = 'Records';
-
-//   return (
-//     <PageContainer
-//       maxWidth="xl"
-//       title={pageTitle}
-//       breadcrumbs={[{ title: pageTitle }]}
-//       actions={
-//         <Stack direction="row" alignItems="center" spacing={1} flexWrap="wrap" useFlexGap>
-//           <Tooltip title="Reload data" placement="bottom" enterDelay={1000}>
-//             <div>
-//               <IconButton size="small" aria-label="refresh" onClick={refresh}>
-//                 <RefreshIcon />
-//               </IconButton>
-//             </div>
-//           </Tooltip>
-
-//           <LocalizationProvider dateAdapter={AdapterDayjs}>
-//             <DatePicker
-//               label="Start"
-//               value={startDate}
-//               onChange={(v) => setStartDate(v)}
-//               views={['year', 'month']}
-//               format="MM/YYYY"
-//               openTo="year"
-//               minDate={dayjs('1900-01-01')}
-//               maxDate={dayjs()}
-//               slotProps={{
-//                 textField: {
-//                   size: 'small',
-//                   placeholder: 'MM/YYYY',
-//                   InputLabelProps: { shrink: true },
-//                 },
-//                 toolbar: { hidden: true },
-//                 field: {
-//                   clearable: true,
-//                 },
-//               }}
-//               sx={{ width: 160 }}
-//             />
-//             <DatePicker
-//               label="End"
-//               value={endDate}
-//               onChange={(v) => setEndDate(v)}
-//               views={['year', 'month']}
-//               format="MM/YYYY"
-//               openTo="year"
-//               minDate={dayjs('1900-01-01')}
-//               maxDate={dayjs()}
-//               slotProps={{
-//                 textField: {
-//                   size: 'small',
-//                   placeholder: 'MM/YYYY',
-//                   InputLabelProps: { shrink: true },
-//                 },
-//                 toolbar: { hidden: true },
-//                 field: {
-//                   clearable: true,
-//                 },
-//               }}
-//               sx={{ width: 160 }}
-//             />
-//           </LocalizationProvider>
-
-//           <Autocomplete
-//             options={authors}
-//             getOptionLabel={(author) => author.name}
-//             renderInput={(params) => (
-//               <TextField {...params} label="Author" size="small" placeholder="All Authors" />
-//             )}
-//             value={selectedAuthor}
-//             onChange={(_, newValue) => setSelectedAuthor(newValue)}
-//             sx={{ minWidth: 200 }}
-//           />
-
-//           <FormControl size="small" sx={{ minWidth: 150 }}>
-//             <InputLabel>Sale Source</InputLabel>
-//             <Select
-//               value={saleSource}
-//               label="Sale Source"
-//               onChange={(e: SelectChangeEvent) => setSaleSource(e.target.value)}
-//             >
-//               <MenuItem value="all">All</MenuItem>
-//               <MenuItem value="distributor">Distributor</MenuItem>
-//               <MenuItem value="hand_sold">Hand Sold</MenuItem>
-//             </Select>
-//           </FormControl>
-
-//           <Button variant="contained" onClick={handleCreateClick} startIcon={<AddIcon />}>
-//             New Sale
-//           </Button>
-//           <Button variant="outlined" onClick={handleImportClick} startIcon={<UploadFileIcon />}>
-//             Import CSV
-//           </Button>
-//         </Stack>
-//       }
-//     >
-//       <Box sx={{ flex: 1, width: '100%' }}>
-//         <StandardDataGrid
-//           rows={rows}
-//           rowCount={rowCount}
-//           columns={columns}
-//           error={error}
-//           onRowClick={handleRowClick}
-//           loading={isLoading}
-//           paginationModel={paginationModel}
-//           onPaginationModelChange={onPaginationModelChange}
-//           sortModel={sortModel}
-//           onSortModelChange={setSortModel}
-//         />
-//       </Box>
-//     </PageContainer>
-//   );
-// }

--- a/frontend/src/utils/formatting.ts
+++ b/frontend/src/utils/formatting.ts
@@ -22,7 +22,7 @@ export function truncate(value: string, maxLength = 30): string {
   return value.length > maxLength ? `${value.slice(0, maxLength)}…` : value;
 }
 
-// /** Format a number as currency with the given ISO currency code. */
-// export function formatCurrencyWithCode(n: number, currencyCode: string): string {
-//   return new Intl.NumberFormat('en-US', { style: 'currency', currency: currencyCode }).format(n);
-// }
+/** Format a number as currency with the given ISO currency code. */
+export function formatCurrencyWithCode(n: number, currencyCode: string): string {
+  return new Intl.NumberFormat('en-US', { style: 'currency', currency: currencyCode }).format(n);
+}

--- a/frontend/src/utils/formatting.ts
+++ b/frontend/src/utils/formatting.ts
@@ -21,3 +21,8 @@ export function formatPercent(rate: number): string {
 export function truncate(value: string, maxLength = 30): string {
   return value.length > maxLength ? `${value.slice(0, maxLength)}…` : value;
 }
+
+// /** Format a number as currency with the given ISO currency code. */
+// export function formatCurrencyWithCode(n: number, currencyCode: string): string {
+//   return new Intl.NumberFormat('en-US', { style: 'currency', currency: currencyCode }).format(n);
+// }


### PR DESCRIPTION
- changed formatting.ts: added formatCurrencyWithCode
- Columns: added distributor and format after Sale Source
- quantitySold → now shows KENP for Kindle Unlimited rows, header updated to "Qty / KENP"
- publisherRevenue split into two columns: "Revenue (Original)" using renderCell to access both amount + currency code, and "Revenue (USD)"