### PR TITLE
feat: automated database backup system (req 7)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,14 @@ JWT_EXPIRATION_HOURS=24
 
 # Currency conversion (Open Exchange Rates)
 CURRENCY_API_APP_ID=your-open-exchange-rates-app-id
+
+# Backup remote (rclone remote path — set up via `rclone config`)
+RCLONE_REMOTE=gdrive:backups/prod
+
+# Backup alerts (Gmail app password — see Google Account → Security → App passwords)
+SMTP_FROM=your-backup-gmail@gmail.com
+SMTP_PASSWORD="xxxx xxxx xxxx xxxx"
+SMTP_TO=alerts-recipient@example.com
+
+# Backup environment label (used in alert email subjects)
+BACKUP_ENV=prod

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ dist/
 *.env
 application-local.properties
 
+# Backups
+backups/
+
 # AI
 .claude/
 requirements/

--- a/backup/Dockerfile
+++ b/backup/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.19
 
-RUN apk add --no-cache bash postgresql16-client rclone
+RUN apk add --no-cache bash postgresql16-client rclone curl
 
 COPY crontab /etc/crontabs/root
 COPY entrypoint.sh /entrypoint.sh

--- a/backup/Dockerfile
+++ b/backup/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.19
 
-RUN apk add --no-cache bash postgresql16-client
+RUN apk add --no-cache bash postgresql16-client rclone
 
 COPY crontab /etc/crontabs/root
 COPY entrypoint.sh /entrypoint.sh

--- a/backup/Dockerfile
+++ b/backup/Dockerfile
@@ -1,0 +1,9 @@
+FROM alpine:3.19
+
+RUN apk add --no-cache bash postgresql16-client
+
+COPY crontab /etc/crontabs/root
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/backup/backup.sh
+++ b/backup/backup.sh
@@ -22,6 +22,10 @@ DB_HOST="${DB_HOST:-db}"
 DB_NAME="${DB_NAME:-book_publishing}"
 DB_USER="${DB_USERNAME:-}"
 RCLONE_REMOTE="${RCLONE_REMOTE:-}"
+SMTP_FROM="${SMTP_FROM:-}"
+SMTP_PASSWORD="${SMTP_PASSWORD:-}"
+SMTP_TO="${SMTP_TO:-}"
+BACKUP_ENV="${BACKUP_ENV:-dev}"
 
 ACTION="${1:-run}"
 TARGET="${2:-}"
@@ -38,6 +42,27 @@ require_env() {
     if [[ -z "${!1:-}" ]]; then
         die "Required environment variable $1 is not set"
     fi
+}
+
+# Send an email alert via Gmail SMTP + app password. Skips if not configured.
+send_alert() {
+    local subject="$1"
+    local body="$2"
+
+    if [[ -z "$SMTP_FROM" || -z "$SMTP_PASSWORD" || -z "$SMTP_TO" ]]; then
+        log "SMTP not configured — skipping alert"
+        return
+    fi
+
+    log "Sending alert: $subject"
+    curl -s --url "smtps://smtp.gmail.com:465" \
+        --user "${SMTP_FROM}:${SMTP_PASSWORD}" \
+        --mail-from "$SMTP_FROM" \
+        --mail-rcpt "$SMTP_TO" \
+        -T <(printf "From: %s\nTo: %s\nSubject: %s\n\n%s\n" \
+            "$SMTP_FROM" "$SMTP_TO" "$subject" "$body") \
+        && log "Alert sent" \
+        || log "WARNING: Failed to send alert email"
 }
 
 # Run a pg command. Inside a container, connect over the network to DB_HOST.
@@ -179,8 +204,21 @@ cmd_pull() {
 # Dispatch
 # ---------------------------------------------------------------------------
 
+# Run with alerting — sends success/failure email after cmd_run
+run_with_alert() {
+    local output
+    if output=$(cmd_run 2>&1); then
+        echo "$output"
+        send_alert "[backup/$BACKUP_ENV] SUCCESS $(date -u '+%Y-%m-%d')" "$output"
+    else
+        echo "$output"
+        send_alert "[backup/$BACKUP_ENV] FAILED $(date -u '+%Y-%m-%d')" "$output"
+        exit 1
+    fi
+}
+
 case "$ACTION" in
-    run)      cmd_run ;;
+    run)      run_with_alert ;;
     push)     cmd_push ;;
     pull)     cmd_pull ;;
     *)        die "Unknown action: $ACTION (expected: run, push, pull)" ;;

--- a/backup/crontab
+++ b/backup/crontab
@@ -1,0 +1,1 @@
+0 2 * * * /scripts/backup.sh run >> /var/log/backup.log 2>&1

--- a/backup/crontab
+++ b/backup/crontab
@@ -1,1 +1,1 @@
-0 2 * * * /scripts/backup.sh run >> /var/log/backup.log 2>&1
+0 2 * * * /backup/backup.sh run >> /var/log/backup.log 2>&1

--- a/backup/entrypoint.sh
+++ b/backup/entrypoint.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # Write env vars to a file that cron jobs can source, since cron
 # does not inherit the container's environment on Alpine.
-env | grep -E '^(DB_|BACKUP_|PGPASSWORD)' > /etc/backup.env
+env | grep -E '^(DB_|BACKUP_|PGPASSWORD|RCLONE_|SMTP_)' > /etc/backup.env
 
 # Wrap the backup script so cron jobs load the env
 cat > /usr/local/bin/run-backup <<'WRAPPER'
@@ -11,12 +11,12 @@ cat > /usr/local/bin/run-backup <<'WRAPPER'
 set -a
 source /etc/backup.env
 set +a
-exec /scripts/backup.sh "$@"
+exec /backup/backup.sh "$@"
 WRAPPER
 chmod +x /usr/local/bin/run-backup
 
 # Update crontab to call the wrapper
-sed -i 's|/scripts/backup.sh|/usr/local/bin/run-backup|' /etc/crontabs/root
+sed -i 's|/backup/backup.sh|/usr/local/bin/run-backup|' /etc/crontabs/root
 
 echo "[backup] Starting cron scheduler ..."
 exec crond -f -l 2

--- a/backup/entrypoint.sh
+++ b/backup/entrypoint.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Write env vars to a file that cron jobs can source, since cron
+# does not inherit the container's environment on Alpine.
+env | grep -E '^(DB_|BACKUP_|PGPASSWORD)' > /etc/backup.env
+
+# Wrap the backup script so cron jobs load the env
+cat > /usr/local/bin/run-backup <<'WRAPPER'
+#!/usr/bin/env bash
+set -a
+source /etc/backup.env
+set +a
+exec /scripts/backup.sh "$@"
+WRAPPER
+chmod +x /usr/local/bin/run-backup
+
+# Update crontab to call the wrapper
+sed -i 's|/scripts/backup.sh|/usr/local/bin/run-backup|' /etc/crontabs/root
+
+echo "[backup] Starting cron scheduler ..."
+exec crond -f -l 2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,8 +40,13 @@ services:
       - DB_HOST=db
       - DB_NAME=book_publishing
       - BACKUP_DIR=/backups
+      - RCLONE_REMOTE=${RCLONE_REMOTE:-}
+      - SMTP_FROM=${SMTP_FROM:-}
+      - SMTP_PASSWORD=${SMTP_PASSWORD:-}
+      - SMTP_TO=${SMTP_TO:-}
+      - BACKUP_ENV=${BACKUP_ENV:-prod}
     volumes:
-      - ./scripts/backup.sh:/scripts/backup.sh:ro
+      - ./backup/backup.sh:/backup/backup.sh:ro
       - ./backups:/backups
       - ${RCLONE_CONFIG:-./rclone.conf}:/root/.config/rclone/rclone.conf:ro
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,23 @@ services:
       retries: 5
     restart: unless-stopped
 
+  # Automated database backups — runs pg_dump daily at 2am UTC
+  backup:
+    build: ./backup
+    environment:
+      - DB_USERNAME=${DB_USERNAME}
+      - PGPASSWORD=${DB_PASSWORD}
+      - DB_HOST=db
+      - DB_NAME=book_publishing
+      - BACKUP_DIR=/backups
+    volumes:
+      - ./scripts/backup.sh:/scripts/backup.sh:ro
+      - ./backups:/backups
+    depends_on:
+      db:
+        condition: service_healthy
+    restart: unless-stopped
+
   # Frontend for local development - Vite dev server with HMR
   frontend:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,7 @@ services:
   # Automated database backups — runs pg_dump daily at 2am UTC
   backup:
     build: ./backup
+    profiles: [prod]
     environment:
       - DB_USERNAME=${DB_USERNAME}
       - PGPASSWORD=${DB_PASSWORD}
@@ -42,6 +43,7 @@ services:
     volumes:
       - ./scripts/backup.sh:/scripts/backup.sh:ro
       - ./backups:/backups
+      - ${RCLONE_CONFIG:-./rclone.conf}:/root/.config/rclone/rclone.conf:ro
     depends_on:
       db:
         condition: service_healthy

--- a/justfile
+++ b/justfile
@@ -22,4 +22,4 @@ format:
 check: api format lint test
 
 backup action="run" target="":
-    ./scripts/backup.sh {{action}} {{target}}
+    ./backup/backup.sh {{action}} {{target}}

--- a/justfile
+++ b/justfile
@@ -20,3 +20,6 @@ format:
     cd frontend && npm run format
 
 check: api format lint test
+
+backup action="run" target="":
+    ./scripts/backup.sh {{action}} {{target}}

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -8,18 +8,20 @@ set -euo pipefail
 #   ./scripts/backup.sh              # run a backup now
 #   ./scripts/backup.sh run          # same as above
 #
+#   ./scripts/backup.sh push         # upload backups to Google Drive
+#   ./scripts/backup.sh pull         # download backups from Google Drive
+#
 # Future subcommands (added in later PRs):
 #   ./scripts/backup.sh list         # list available backups
 #   ./scripts/backup.sh restore <f>  # restore from a backup file
 #   ./scripts/backup.sh validate <f> # validate a backup file
-#   ./scripts/backup.sh push         # sync to Google Drive
-#   ./scripts/backup.sh pull         # fetch from Google Drive
 # ---------------------------------------------------------------------------
 
 BACKUP_DIR="${BACKUP_DIR:-./backups}"
 DB_HOST="${DB_HOST:-db}"
 DB_NAME="${DB_NAME:-book_publishing}"
 DB_USER="${DB_USERNAME:-}"
+RCLONE_REMOTE="${RCLONE_REMOTE:-gdrive:backups}"
 
 ACTION="${1:-run}"
 TARGET="${2:-}"
@@ -107,6 +109,13 @@ cmd_run() {
     prune "weekly"  4
     prune "monthly" 12
 
+    # 6. Push to remote (if rclone is configured)
+    if command -v rclone > /dev/null 2>&1; then
+        cmd_push
+    else
+        log "rclone not available — skipping remote upload"
+    fi
+
     log "Backup complete"
 }
 
@@ -135,10 +144,42 @@ prune() {
 }
 
 # ---------------------------------------------------------------------------
+# push — upload local backups to Google Drive (copy-only, never deletes remote)
+# ---------------------------------------------------------------------------
+
+cmd_push() {
+    if ! command -v rclone > /dev/null 2>&1; then
+        die "rclone is not installed"
+    fi
+
+    log "Uploading backups to $RCLONE_REMOTE ..."
+    rclone copy "$BACKUP_DIR" "$RCLONE_REMOTE" --log-level INFO
+    log "Upload complete"
+}
+
+# ---------------------------------------------------------------------------
+# pull — download backups from Google Drive to local
+# ---------------------------------------------------------------------------
+
+cmd_pull() {
+    if ! command -v rclone > /dev/null 2>&1; then
+        die "rclone is not installed"
+    fi
+
+    mkdir -p "$BACKUP_DIR"/{daily,weekly,monthly}
+
+    log "Downloading backups from $RCLONE_REMOTE ..."
+    rclone copy "$RCLONE_REMOTE" "$BACKUP_DIR" --log-level INFO
+    log "Download complete"
+}
+
+# ---------------------------------------------------------------------------
 # Dispatch
 # ---------------------------------------------------------------------------
 
 case "$ACTION" in
     run)      cmd_run ;;
-    *)        die "Unknown action: $ACTION (expected: run)" ;;
+    push)     cmd_push ;;
+    pull)     cmd_pull ;;
+    *)        die "Unknown action: $ACTION (expected: run, push, pull)" ;;
 esac

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -17,7 +17,7 @@ set -euo pipefail
 # ---------------------------------------------------------------------------
 
 BACKUP_DIR="${BACKUP_DIR:-./backups}"
-DB_CONTAINER="${DB_CONTAINER:-$(docker compose ps -q db)}"
+DB_HOST="${DB_HOST:-db}"
 DB_NAME="${DB_NAME:-book_publishing}"
 DB_USER="${DB_USERNAME:-}"
 
@@ -38,6 +38,19 @@ require_env() {
     fi
 }
 
+# Run a pg command. Inside a container, connect over the network to DB_HOST.
+# From the host, use docker exec into the db container (no network needed).
+pg_cmd() {
+    local cmd="$1"; shift
+    if [[ -f /.dockerenv ]]; then
+        "$cmd" -h "$DB_HOST" -U "$DB_USER" "$@"
+    else
+        local container
+        container="$(docker compose ps -q db)"
+        docker exec "$container" "$cmd" -U "$DB_USER" "$@"
+    fi
+}
+
 # ---------------------------------------------------------------------------
 # run — create a backup, promote if applicable, prune old backups
 # ---------------------------------------------------------------------------
@@ -53,7 +66,7 @@ cmd_run() {
 
     # 1. Dump
     log "Starting pg_dump for $DB_NAME ..."
-    if ! docker exec "$DB_CONTAINER" pg_dump -Fc -U "$DB_USER" "$DB_NAME" > "$daily_file"; then
+    if ! pg_cmd pg_dump -Fc "$DB_NAME" > "$daily_file"; then
         rm -f "$daily_file"
         die "pg_dump failed"
     fi
@@ -63,11 +76,15 @@ cmd_run() {
     log "Dump complete: $daily_file ($size)"
 
     # 2. Validate
-    log "Validating dump ..."
-    if ! docker exec -i "$DB_CONTAINER" pg_restore --list < "$daily_file" > /dev/null 2>&1; then
-        die "Dump validation failed — file may be corrupted"
+    if command -v pg_restore > /dev/null 2>&1; then
+        log "Validating dump ..."
+        if ! pg_restore --list "$daily_file" > /dev/null 2>&1; then
+            die "Dump validation failed — file may be corrupted"
+        fi
+        log "Validation passed"
+    else
+        log "pg_restore not found on host — skipping validation"
     fi
-    log "Validation passed"
 
     # 3. Promote to weekly (Sunday = 0 in date +%w on Linux, 7 on some systems)
     local dow

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -21,7 +21,7 @@ BACKUP_DIR="${BACKUP_DIR:-./backups}"
 DB_HOST="${DB_HOST:-db}"
 DB_NAME="${DB_NAME:-book_publishing}"
 DB_USER="${DB_USERNAME:-}"
-RCLONE_REMOTE="${RCLONE_REMOTE:-gdrive:backups}"
+RCLONE_REMOTE="${RCLONE_REMOTE:-}"
 
 ACTION="${1:-run}"
 TARGET="${2:-}"
@@ -109,11 +109,11 @@ cmd_run() {
     prune "weekly"  4
     prune "monthly" 12
 
-    # 6. Push to remote (if rclone is configured)
-    if command -v rclone > /dev/null 2>&1; then
+    # 6. Push to remote (if rclone is available and configured)
+    if command -v rclone > /dev/null 2>&1 && [[ -n "$RCLONE_REMOTE" ]]; then
         cmd_push
     else
-        log "rclone not available — skipping remote upload"
+        log "rclone not configured — skipping remote upload"
     fi
 
     log "Backup complete"
@@ -151,6 +151,7 @@ cmd_push() {
     if ! command -v rclone > /dev/null 2>&1; then
         die "rclone is not installed"
     fi
+    require_env RCLONE_REMOTE
 
     log "Uploading backups to $RCLONE_REMOTE ..."
     rclone copy "$BACKUP_DIR" "$RCLONE_REMOTE" --log-level INFO
@@ -165,6 +166,7 @@ cmd_pull() {
     if ! command -v rclone > /dev/null 2>&1; then
         die "rclone is not installed"
     fi
+    require_env RCLONE_REMOTE
 
     mkdir -p "$BACKUP_DIR"/{daily,weekly,monthly}
 

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# backup.sh — pg_dump-based backup with staggered retention
+#
+# Usage:
+#   ./scripts/backup.sh              # run a backup now
+#   ./scripts/backup.sh run          # same as above
+#
+# Future subcommands (added in later PRs):
+#   ./scripts/backup.sh list         # list available backups
+#   ./scripts/backup.sh restore <f>  # restore from a backup file
+#   ./scripts/backup.sh validate <f> # validate a backup file
+#   ./scripts/backup.sh push         # sync to Google Drive
+#   ./scripts/backup.sh pull         # fetch from Google Drive
+# ---------------------------------------------------------------------------
+
+BACKUP_DIR="${BACKUP_DIR:-./backups}"
+DB_CONTAINER="${DB_CONTAINER:-$(docker compose ps -q db)}"
+DB_NAME="${DB_NAME:-book_publishing}"
+DB_USER="${DB_USERNAME:-}"
+
+ACTION="${1:-run}"
+TARGET="${2:-}"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+log()  { echo "[backup] $(date -u '+%Y-%m-%d %H:%M:%S UTC') $*"; }
+err()  { log "ERROR: $*" >&2; }
+die()  { err "$@"; exit 1; }
+
+require_env() {
+    if [[ -z "${!1:-}" ]]; then
+        die "Required environment variable $1 is not set"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# run — create a backup, promote if applicable, prune old backups
+# ---------------------------------------------------------------------------
+
+cmd_run() {
+    require_env DB_USERNAME
+
+    mkdir -p "$BACKUP_DIR"/{daily,weekly,monthly}
+
+    local today
+    today="$(date -u '+%Y-%m-%d')"
+    local daily_file="$BACKUP_DIR/daily/backup-${today}.dump"
+
+    # 1. Dump
+    log "Starting pg_dump for $DB_NAME ..."
+    if ! docker exec "$DB_CONTAINER" pg_dump -Fc -U "$DB_USER" "$DB_NAME" > "$daily_file"; then
+        rm -f "$daily_file"
+        die "pg_dump failed"
+    fi
+
+    local size
+    size="$(du -h "$daily_file" | cut -f1)"
+    log "Dump complete: $daily_file ($size)"
+
+    # 2. Validate
+    log "Validating dump ..."
+    if ! docker exec -i "$DB_CONTAINER" pg_restore --list < "$daily_file" > /dev/null 2>&1; then
+        die "Dump validation failed — file may be corrupted"
+    fi
+    log "Validation passed"
+
+    # 3. Promote to weekly (Sunday = 0 in date +%w on Linux, 7 on some systems)
+    local dow
+    dow="$(date -u '+%w')"
+    if [[ "$dow" -eq 0 ]]; then
+        cp "$daily_file" "$BACKUP_DIR/weekly/backup-${today}.dump"
+        log "Promoted to weekly"
+    fi
+
+    # 4. Promote to monthly (1st of month)
+    local dom
+    dom="$(date -u '+%d')"
+    if [[ "$dom" -eq 1 ]]; then
+        cp "$daily_file" "$BACKUP_DIR/monthly/backup-${today}.dump"
+        log "Promoted to monthly"
+    fi
+
+    # 5. Prune
+    prune "daily"   7
+    prune "weekly"  4
+    prune "monthly" 12
+
+    log "Backup complete"
+}
+
+# ---------------------------------------------------------------------------
+# prune — keep only the N most recent dumps in a tier directory
+# ---------------------------------------------------------------------------
+
+prune() {
+    local tier="$1"
+    local keep="$2"
+    local dir="$BACKUP_DIR/$tier"
+
+    local count
+    count="$(find "$dir" -name 'backup-*.dump' | wc -l | tr -d ' ')"
+
+    if [[ "$count" -le "$keep" ]]; then
+        return
+    fi
+
+    local to_delete
+    to_delete=$(ls -1 "$dir"/backup-*.dump | sort -r | tail -n +"$((keep + 1))")
+    for f in $to_delete; do
+        log "Pruning $f"
+        rm -f "$f"
+    done
+}
+
+# ---------------------------------------------------------------------------
+# Dispatch
+# ---------------------------------------------------------------------------
+
+case "$ACTION" in
+    run)      cmd_run ;;
+    *)        die "Unknown action: $ACTION (expected: run)" ;;
+esac


### PR DESCRIPTION
Resolves req 7 (backups)

## Summary
Implements an automated backup solution for the system's PostgreSQL database per Ev 3 requirement 7. Backups are taken via `pg_dump` in custom format (compressed, restorable), stored with staggered retention (7 daily, 4 weekly, 12 monthly), synced to Google Drive as a separate system with separate credentials, and alert on success/failure via email.

## What's included
- **backup/backup.sh**: core script handling dump, validation, retention promotion/pruning, Google Drive sync via rclone, and email alerts via Gmail SMTP
- **backup/Dockerfile + entrypoint.sh + crontab**: lightweight Alpine container with postgresql-client, rclone, and curl that runs the backup script daily at 2am UTC via crond
- **docker-compose.yml**: new `backup` service behind `prod` profile — only runs in production, not during local dev
- **justfile**: `just backup` recipe with subcommand passthrough (`just backup run`, `just backup push`, `just backup pull`)
- **.env.example**: documents new env vars (RCLONE_REMOTE, SMTP_FROM/PASSWORD/TO, BACKUP_ENV)
- **.gitignore**: excludes `backups/` directory

## Requirements coverage
- **7.1** (automatic daily backups): crond in backup container, 2am UTC
- **7.2** (staggered retention): 7 daily, 4 weekly (Sunday), 12 monthly (1st)
- **7.3** (separate system): Google Drive via rclone
- **7.4** (separate credentials): dedicated Gmail account with app password
- **7.5** (progress/failure alerts): email via Gmail SMTP on every backup run
- **7.6** (out-of-band): background pg_dump, no in-band application changes

## Technical decisions
- **pg_dump custom format (-Fc)** over plain SQL: compressed, supports selective/parallel restore, industry standard
- **rclone copy (not sync)** for uploads: upload-only, never deletes remote files — prevents accidental wipe of all backups if local dir is cleared. Remote pruning can be added later if backup sizes grow.
- **/.dockerenv detection** in backup.sh to auto-switch between `docker exec` (host) and direct `pg_dump` (container) — same script works in both contexts
- **RCLONE_REMOTE required** (no default): prevents dev from accidentally uploading to prod's Google Drive folder
- **curl for SMTP** instead of msmtp/OAuth: Gmail app password + curl's native SMTP support, no extra tools needed
- **Backup container behind prod profile**: `docker compose --profile prod up` starts it, regular `docker compose up` (dev) does not
- **Validation via pg_restore --list**: confirms dump integrity after each backup, gracefully skips on host if pg_restore not installed

## Still to come (future PRs)
- `just backup list`, `just backup validate`, `just backup restore` commands
- Backup admin guide (req 4.4)
- Justfile refresh
- Retention/pruning test suite