### PR TITLE
chore: justfile refresh with groups and dev shortcuts

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,27 +1,87 @@
+set dotenv-load
+
+# show available commands
+[private]
+default:
+    @just --list
+
+# --- dev ---
+
+# start containers (--build to rebuild, --force to recreate)
+[group('dev')]
+[arg('build', long, value='--build')]
+[arg('force', long, value='--force-recreate')]
+up profile="dev" build="" force="":
+    docker compose --profile {{profile}} up -d {{build}} {{force}}
+
+# stop all containers
+[group('dev')]
+down:
+    docker compose down
+
+# stop and destroy database volume
+[group('dev')]
+[confirm("This will delete the database volume. Continue?")]
+nuke:
+    docker compose down -v
+
+# tail container logs
+[group('dev')]
+logs *service:
+    docker compose logs -f {{service}}
+
+# open psql shell
+[group('dev')]
+db:
+    docker exec -it $(docker compose ps -q db) psql -U "$DB_USERNAME" -d book_publishing
+
+# show container status
+[group('dev')]
+status:
+    docker compose ps
+
+# --- code quality ---
+
+# regenerate api client
+[group('code quality')]
 api:
     cd frontend && npm run api:generate
 
+# run all tests
+[group('code quality')]
 test:
     cd backend && ./gradlew test
     cd frontend && npm run test -- --run
 
+# run backend tests only
+[group('code quality')]
 test-backend:
     cd backend && ./gradlew test
 
+# run frontend tests only
+[group('code quality')]
 test-frontend:
     cd frontend && npm run test -- --run
 
+# check formatting and lint
+[group('code quality')]
 lint:
     cd backend && ./gradlew spotlessCheck
     cd frontend && npm run lint
 
+# auto-fix formatting
+[group('code quality')]
 format:
     cd backend && ./gradlew spotlessApply
     cd frontend && npm run format
 
+# run all checks (api, format, lint, test)
+[group('code quality')]
 check: api format lint test
 
-set dotenv-load
+# --- backup ---
 
-backup action="run" target="":
-    ./backup/backup.sh {{action}} {{target}}
+# database backup (run, list, validate, restore, push, pull)
+[group('backup')]
+backup *args:
+    ./backup/backup.sh {{args}}


### PR DESCRIPTION
Builds on #196

## Summary
Modernizes the justfile with grouped recipes, doc comments, and convenience commands for daily development.

## Changes
- **Recipe groups** (`dev`, `code quality`, `backup`) via `[group()]` — organizes `just --list` output
- **Dev shortcuts**: `up` (with `--build`/`--force` flags), `down`, `nuke` (with `[confirm]`), `logs`, `db`, `status`
- **`set dotenv-load`** — auto-loads `.env` so backup commands work without manual sourcing
- **`default` recipe** — bare `just` shows available commands
- **`backup` uses variadic `*args`** for clean listing

## `just --list` output
```
[backup]
backup *args                       # database backup (run, list, validate, restore, push, pull)

[code quality]
api                                # regenerate api client
check                              # run all checks (api, format, lint, test)
format                             # auto-fix formatting
lint                               # check formatting and lint
test                               # run all tests
test-backend                       # run backend tests only
test-frontend                      # run frontend tests only

[dev]
db                                 # open psql shell
down                               # stop all containers
logs *service                      # tail container logs
nuke                               # stop and destroy database volume
status                             # show container status
up profile="dev" build="" force="" # start containers (--build to rebuild, --force to recreate)
```