### PR TITLE
fix: rewrite sale validation, unblock handsold/KU sales

### DIFF
--- a/backend/src/main/java/edu/duke/bookpublishing/sales/Sale.java
+++ b/backend/src/main/java/edu/duke/bookpublishing/sales/Sale.java
@@ -56,7 +56,7 @@ public class Sale {
   private SaleSource saleSource;
 
   @Enumerated(EnumType.STRING)
-  @Column(name = "distributor", nullable = false)
+  @Column(name = "distributor")
   private SaleDistributor distributor;
 
   @Enumerated(EnumType.STRING)
@@ -74,7 +74,7 @@ public class Sale {
   private Integer saleYear;
 
   @Positive
-  @Column(name = "quantity_sold", nullable = false)
+  @Column(name = "quantity_sold")
   private Integer quantitySold;
 
   @Positive

--- a/backend/src/main/java/edu/duke/bookpublishing/sales/SaleService.java
+++ b/backend/src/main/java/edu/duke/bookpublishing/sales/SaleService.java
@@ -210,6 +210,7 @@ public class SaleService {
             .saleMonth(request.saleMonth())
             .saleYear(request.saleYear())
             .quantitySold(request.quantitySold())
+            .kenp(request.kenp())
             .saleCurrency(request.saleCurrency())
             .originalPublisherRevenue(originalPublisherRevenue)
             .publisherRevenue(publisherRevenue)

--- a/backend/src/main/java/edu/duke/bookpublishing/sales/dto/SaleRequest.java
+++ b/backend/src/main/java/edu/duke/bookpublishing/sales/dto/SaleRequest.java
@@ -36,11 +36,7 @@ public record SaleRequest(
             requiredMode = REQUIRED)
         @NotNull(message = "Sale source is required")
         SaleSource saleSource,
-    @Schema(
-            description = "The distributor through which the sale was made",
-            example = "AMAZON",
-            requiredMode = REQUIRED)
-        @NotNull(message = "Distributor is required")
+    @Schema(description = "The distributor through which the sale was made", example = "AMAZON")
         SaleDistributor distributor,
     @Schema(
             description = "The format of the book that was sold",
@@ -105,97 +101,32 @@ public record SaleRequest(
     return !requested.isAfter(YearMonth.now());
   }
 
+  @AssertTrue(message = "Invalid fields for sale source")
+  @Schema(hidden = true)
+  public boolean isValidForSource() {
+    if (saleSource == null) return true;
+    if (saleSource == SaleSource.HAND_SOLD) {
+      return distributor == null
+          && (format == null || format == SaleFormat.PRINT)
+          && publisherRevenue == null
+          && (saleCurrency == null || saleCurrency == Currency.USD);
+    }
+    // DISTRIBUTOR
+    return distributor != null
+        && publisherRevenue != null
+        && (format == null || distributor.allowsFormat(format));
+  }
+
   @AssertTrue(
       message =
-          "Publisher revenue must be provided for distributor sales and omitted for handsold sales")
+          "KINDLE_UNLIMITED requires KENP and no quantity; other formats require quantity and no"
+              + " KENP")
   @Schema(hidden = true)
-  public boolean isPublisherRevenueValidForSource() {
-    if (saleSource == null) return true;
-    if (saleSource == SaleSource.DISTRIBUTOR) {
-      return publisherRevenue != null;
-    }
-    return publisherRevenue == null;
-  }
-
-  @AssertTrue(message = "Distributor only present if saleSource is Distributor")
-  @Schema(hidden = true)
-  public boolean isDistributorValid() {
-    if (distributor == null) return true;
-    if (saleSource == SaleSource.DISTRIBUTOR) {
-      return distributor != null;
-    }
-    return distributor == null;
-  }
-
-  @AssertTrue(message = "Hand sold distributor must be print")
-  @Schema(hidden = true)
-  public boolean isFormatValidForHandsold() {
-    if (format == null) return true;
-    if (saleSource == SaleSource.HAND_SOLD) {
-      return format == SaleFormat.PRINT;
-    }
-    return true;
-  }
-
-  @AssertTrue(message = "Format must be print for Ingram Spark distributor")
-  @Schema(hidden = true)
-  public boolean isFormatValidForIngramSparkDistributor() {
-    if (format == null) return true;
-    if (distributor == SaleDistributor.INGRAM_SPARK) {
-      return format == SaleFormat.PRINT;
-    }
-    return true;
-  }
-
-  @AssertTrue(message = "Format must be either PRINT or EBOOK for distributor \"other\"")
-  @Schema(hidden = true)
-  public boolean isFormatValidForOtherDistributor() {
-    if (format == null) return true;
-    if (distributor == SaleDistributor.OTHER) {
-      return format == SaleFormat.PRINT || format == SaleFormat.EBOOK;
-    }
-    return true;
-  }
-
-  @AssertTrue(message = "Format must be PRINT, EBOOK, or KINDLE_UNLIMITED for Distrbutor Amazon")
-  @Schema(hidden = true)
-  public boolean isFormatValidForAmazonDistributor() {
-    if (format == null) return true;
-    if (distributor == SaleDistributor.AMAZON) {
-      return format == SaleFormat.PRINT
-          || format == SaleFormat.EBOOK
-          || format == SaleFormat.KINDLE_UNLIMITED;
-    }
-    return true;
-  }
-
-  @AssertTrue(message = "Quantity sold is unspecified if format is KINDLE_UNLIMITED")
-  @Schema(hidden = true)
-  public boolean isQuantitySoldValid() {
-    if (quantitySold == null) return true;
-    if (format == SaleFormat.KINDLE_UNLIMITED) {
-      return quantitySold == null;
-    }
-    return quantitySold != null;
-  }
-
-  @AssertTrue(message = "KENP is required for format KINDLE_UNLIMITED")
-  @Schema(hidden = true)
-  public boolean isKenpValid() {
+  public boolean isFormatFieldsValid() {
     if (format == null) return true;
     if (format == SaleFormat.KINDLE_UNLIMITED) {
-      return kenp != null;
+      return kenp != null && quantitySold == null;
     }
-    return kenp == null;
-  }
-
-  @AssertTrue(message = "Hand sold records must have currency of USD")
-  @Schema(hidden = true)
-  public boolean isHandSoldCurrencyValid() {
-    if (saleSource == null || saleCurrency == null) return true;
-    if (saleSource == SaleSource.HAND_SOLD) {
-      return saleCurrency == Currency.USD;
-    }
-    return saleCurrency != null;
+    return quantitySold != null && kenp == null;
   }
 }

--- a/backend/src/main/java/edu/duke/bookpublishing/sales/enums/SaleDistributor.java
+++ b/backend/src/main/java/edu/duke/bookpublishing/sales/enums/SaleDistributor.java
@@ -1,12 +1,24 @@
 package edu.duke.bookpublishing.sales.enums;
 
+import java.util.Set;
+
 /**
  * Denotes the distributor for the sale that was made, e.g. AMAZON
  *
  * @author Daniel Rodriguez-Florido
  */
 public enum SaleDistributor {
-  INGRAM_SPARK,
-  AMAZON,
-  OTHER
+  INGRAM_SPARK(Set.of(SaleFormat.PRINT)),
+  AMAZON(Set.of(SaleFormat.PRINT, SaleFormat.EBOOK, SaleFormat.KINDLE_UNLIMITED)),
+  OTHER(Set.of(SaleFormat.PRINT, SaleFormat.EBOOK));
+
+  private final Set<SaleFormat> allowedFormats;
+
+  SaleDistributor(Set<SaleFormat> allowedFormats) {
+    this.allowedFormats = allowedFormats;
+  }
+
+  public boolean allowsFormat(SaleFormat format) {
+    return allowedFormats.contains(format);
+  }
 }

--- a/backend/src/test/java/edu/duke/bookpublishing/sales/SaleControllerTest.java
+++ b/backend/src/test/java/edu/duke/bookpublishing/sales/SaleControllerTest.java
@@ -244,12 +244,319 @@ class SaleControllerTest {
   }
 
   @Test
-  void createHandsoldSaleRejectsInvalidDistributorValidation() throws Exception {
+  void createHandsoldSaleSucceeds() throws Exception {
     Cookie token = login();
     Book book = createBook();
 
     SaleRequest request =
         saleRequest(book.getId(), SaleSource.HAND_SOLD, 2, 2024, 10, null, false, "Handsale");
+
+    mockMvc
+        .perform(
+            post("/api/sales")
+                .cookie(token)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.saleSource").value("HAND_SOLD"))
+        .andExpect(jsonPath("$.distributor", nullValue()));
+  }
+
+  @Test
+  void createHandsoldSaleRejectsNonNullDistributor() throws Exception {
+    Cookie token = login();
+    Book book = createBook();
+
+    SaleRequest request =
+        new SaleRequest(
+            book.getId(),
+            SaleSource.HAND_SOLD,
+            SaleDistributor.AMAZON,
+            SaleFormat.PRINT,
+            2,
+            2024,
+            10,
+            null,
+            Currency.USD,
+            null,
+            null,
+            false,
+            "Handsale");
+
+    mockMvc
+        .perform(
+            post("/api/sales")
+                .cookie(token)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void createDistributorSaleRejectsNullDistributor() throws Exception {
+    Cookie token = login();
+    Book book = createBook();
+
+    SaleRequest request =
+        new SaleRequest(
+            book.getId(),
+            SaleSource.DISTRIBUTOR,
+            null,
+            SaleFormat.PRINT,
+            2,
+            2024,
+            10,
+            null,
+            Currency.USD,
+            new BigDecimal("50.00"),
+            new BigDecimal("50.00"),
+            false,
+            null);
+
+    mockMvc
+        .perform(
+            post("/api/sales")
+                .cookie(token)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void createKindleUnlimitedSaleSucceeds() throws Exception {
+    Cookie token = login();
+    Book book = createBook();
+
+    SaleRequest request =
+        new SaleRequest(
+            book.getId(),
+            SaleSource.DISTRIBUTOR,
+            SaleDistributor.AMAZON,
+            SaleFormat.KINDLE_UNLIMITED,
+            2,
+            2024,
+            null,
+            500,
+            Currency.USD,
+            new BigDecimal("50.00"),
+            new BigDecimal("50.00"),
+            false,
+            null);
+
+    mockMvc
+        .perform(
+            post("/api/sales")
+                .cookie(token)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.format").value("KINDLE_UNLIMITED"))
+        .andExpect(jsonPath("$.kenp").value(500))
+        .andExpect(jsonPath("$.quantitySold", nullValue()));
+  }
+
+  @Test
+  void createHandsoldSaleRejectsEbookFormat() throws Exception {
+    Cookie token = login();
+    Book book = createBook();
+
+    SaleRequest request =
+        new SaleRequest(
+            book.getId(),
+            SaleSource.HAND_SOLD,
+            null,
+            SaleFormat.EBOOK,
+            2,
+            2024,
+            10,
+            null,
+            Currency.USD,
+            null,
+            null,
+            false,
+            null);
+
+    mockMvc
+        .perform(
+            post("/api/sales")
+                .cookie(token)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void createSaleRejectsInvalidFormatForDistributor() throws Exception {
+    Cookie token = login();
+    Book book = createBook();
+
+    SaleRequest request =
+        new SaleRequest(
+            book.getId(),
+            SaleSource.DISTRIBUTOR,
+            SaleDistributor.INGRAM_SPARK,
+            SaleFormat.EBOOK,
+            2,
+            2024,
+            10,
+            null,
+            Currency.USD,
+            new BigDecimal("50.00"),
+            new BigDecimal("50.00"),
+            false,
+            null);
+
+    mockMvc
+        .perform(
+            post("/api/sales")
+                .cookie(token)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void createKindleUnlimitedSaleRejectsQuantitySold() throws Exception {
+    Cookie token = login();
+    Book book = createBook();
+
+    SaleRequest request =
+        new SaleRequest(
+            book.getId(),
+            SaleSource.DISTRIBUTOR,
+            SaleDistributor.AMAZON,
+            SaleFormat.KINDLE_UNLIMITED,
+            2,
+            2024,
+            10,
+            500,
+            Currency.USD,
+            new BigDecimal("50.00"),
+            new BigDecimal("50.00"),
+            false,
+            null);
+
+    mockMvc
+        .perform(
+            post("/api/sales")
+                .cookie(token)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void createPrintSaleRejectsNullQuantitySold() throws Exception {
+    Cookie token = login();
+    Book book = createBook();
+
+    SaleRequest request =
+        new SaleRequest(
+            book.getId(),
+            SaleSource.DISTRIBUTOR,
+            SaleDistributor.OTHER,
+            SaleFormat.PRINT,
+            2,
+            2024,
+            null,
+            null,
+            Currency.USD,
+            new BigDecimal("50.00"),
+            new BigDecimal("50.00"),
+            false,
+            null);
+
+    mockMvc
+        .perform(
+            post("/api/sales")
+                .cookie(token)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void createEbookSaleSucceeds() throws Exception {
+    Cookie token = login();
+    Book book = createBook();
+
+    SaleRequest request =
+        new SaleRequest(
+            book.getId(),
+            SaleSource.DISTRIBUTOR,
+            SaleDistributor.AMAZON,
+            SaleFormat.EBOOK,
+            2,
+            2024,
+            10,
+            null,
+            Currency.USD,
+            new BigDecimal("50.00"),
+            new BigDecimal("50.00"),
+            false,
+            null);
+
+    mockMvc
+        .perform(
+            post("/api/sales")
+                .cookie(token)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.format").value("EBOOK"))
+        .andExpect(jsonPath("$.distributor").value("AMAZON"));
+  }
+
+  @Test
+  void createHandsoldSaleRejectsNonUsdCurrency() throws Exception {
+    Cookie token = login();
+    Book book = createBook();
+
+    SaleRequest request =
+        new SaleRequest(
+            book.getId(),
+            SaleSource.HAND_SOLD,
+            null,
+            SaleFormat.PRINT,
+            2,
+            2024,
+            10,
+            null,
+            Currency.GBP,
+            null,
+            null,
+            false,
+            null);
+
+    mockMvc
+        .perform(
+            post("/api/sales")
+                .cookie(token)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void createKindleUnlimitedSaleRejectsNullKenp() throws Exception {
+    Cookie token = login();
+    Book book = createBook();
+
+    SaleRequest request =
+        new SaleRequest(
+            book.getId(),
+            SaleSource.DISTRIBUTOR,
+            SaleDistributor.AMAZON,
+            SaleFormat.KINDLE_UNLIMITED,
+            2,
+            2024,
+            null,
+            null,
+            Currency.USD,
+            new BigDecimal("50.00"),
+            new BigDecimal("50.00"),
+            false,
+            null);
 
     mockMvc
         .perform(

--- a/frontend/src/api/generated/models/SaleRequest.ts
+++ b/frontend/src/api/generated/models/SaleRequest.ts
@@ -17,7 +17,7 @@ export type SaleRequest = {
     /**
      * The distributor through which the sale was made
      */
-    distributor: SaleRequest.distributor;
+    distributor?: SaleRequest.distributor;
     /**
      * The format of the book that was sold
      */


### PR DESCRIPTION
Fixes broken validation that prevented handsold and Kindle Unlimited sales from being created through the API.

## Summary

The `SaleRequest` cross-field validation had two classes of bugs:
1. **Unconditional `@NotNull` on `distributor`** blocked all handsold sales (which have no distributor)
2. **Null-guard logic errors** in `isDistributorValid()` and `isQuantitySoldValid()` made both methods no-ops — they never enforced their intended constraints

Additionally, `Sale.java` had `nullable = false` on `distributor` and `quantity_sold` columns, which would block handsold and KU sales at the DB level. And the create path in `SaleService` was missing `.kenp()` in the builder, so KU sales silently dropped KENP values.

The 8 scattered `@AssertTrue` methods are consolidated into 2 (`isValidForSource`, `isFormatFieldsValid`), and allowed-format-per-distributor data is moved into the `SaleDistributor` enum so adding a new distributor doesn't require touching validation.

Per Ev3 requirements: distributor is required iff sale source is distributor; currency is locked to USD for handsold records.

## Files changed
- `SaleDistributor.java` — each enum value declares its allowed formats
- `SaleRequest.java` — removed `@NotNull` on distributor, replaced 8 validation methods with 2
- `Sale.java` — `distributor` and `quantity_sold` columns now nullable
- `SaleService.java` — added missing `.kenp()` to create builder
- `SaleControllerTest.java` — fixed broken handsold test, added happy paths (handsold, ebook, KU) and rejection tests for all validation branches
- `SaleRequest.ts` — regenerated API client (distributor now optional)

## Technical decisions
- Consolidated validation trades per-field error messages for simplicity. The frontend already constrains the form by sale source, so backend messages for cross-field rules aren't user-facing in practice.
- Format-per-distributor data lives on the enum rather than in validation code — adding a distributor is now a one-line change.
- `ddl-auto=update` handles the column nullability change automatically.

## Test plan
- [x] `just check` passes (API regen, format, lint, backend + frontend tests)
- [ ] Manual: create a handsold sale through the UI
- [ ] Manual: create a KU sale through the UI
- [ ] Manual: verify rejection messages appear for invalid combinations