### PR TITLE
feat: add csv export button to sales list (req 3.1.5)

### DIFF
--- a/frontend/src/features/sales/SaleList.tsx
+++ b/frontend/src/features/sales/SaleList.tsx
@@ -1,6 +1,7 @@
 import AddIcon from '@mui/icons-material/Add';
 import CommentIcon from '@mui/icons-material/Comment';
 import DeleteIcon from '@mui/icons-material/Delete';
+import DownloadIcon from '@mui/icons-material/Download';
 import RefreshIcon from '@mui/icons-material/Refresh';
 import UploadFileIcon from '@mui/icons-material/UploadFile';
 import Autocomplete from '@mui/material/Autocomplete';
@@ -117,6 +118,15 @@ export default function SaleList() {
   const handleCreateClick = React.useCallback(() => navigate('/sales/new'), [navigate]);
 
   const handleImportClick = React.useCallback(() => navigate('/sales/import'), [navigate]);
+
+  const handleExportClick = React.useCallback(() => {
+    const params = new URLSearchParams();
+    if (startDate) params.set('startDate', startDate.startOf('month').format('YYYY-MM-DD'));
+    if (endDate) params.set('endDate', endDate.endOf('month').format('YYYY-MM-DD'));
+    if (selectedAuthor?.id) params.set('authorId', String(selectedAuthor.id));
+    if (saleSource !== 'all') params.set('saleSource', saleSource.toUpperCase());
+    window.open(`/api/sales/export?${params.toString()}`, '_blank');
+  }, [startDate, endDate, selectedAuthor, saleSource]);
 
   const handleRowDelete = React.useCallback(
     (sale: SaleResponse) => async () => {
@@ -329,7 +339,7 @@ export default function SaleList() {
                   clearable: true,
                 },
               }}
-              sx={{ width: 160 }}
+              sx={{ width: 120 }}
             />
             <DatePicker
               label="End"
@@ -351,7 +361,7 @@ export default function SaleList() {
                   clearable: true,
                 },
               }}
-              sx={{ width: 160 }}
+              sx={{ width: 120 }}
             />
           </LocalizationProvider>
 
@@ -366,7 +376,7 @@ export default function SaleList() {
             sx={{ minWidth: 200 }}
           />
 
-          <FormControl size="small" sx={{ minWidth: 150 }}>
+          <FormControl size="small" sx={{ minWidth: 120 }}>
             <InputLabel>Sale Source</InputLabel>
             <Select
               value={saleSource}
@@ -383,7 +393,10 @@ export default function SaleList() {
             New Sale
           </Button>
           <Button variant="outlined" onClick={handleImportClick} startIcon={<UploadFileIcon />}>
-            Import CSV
+            Import
+          </Button>
+          <Button variant="outlined" onClick={handleExportClick} startIcon={<DownloadIcon />}>
+            Export
           </Button>
         </Stack>
       }


### PR DESCRIPTION
Builds on #202

## Summary
Adds an "Export" button to the sales list toolbar that downloads filtered sales as CSV per req 3.1.5. Uses the `/api/sales/export` endpoint from #202 with the current filter params (date range, author, sale source).

## Files changed
- **SaleList.tsx** — added Export button with DownloadIcon, builds export URL from current filters, opens in new tab. Tightened date picker widths (160→120) and sale source (150→120) to fit the new button without overflow. Shortened button labels to "Import"/"Export".