### PR TITLE
fix: currency-aware sorting for original revenue (req 3.1.1)

### DIFF
--- a/backend/src/main/java/edu/duke/bookpublishing/common/SortUtils.java
+++ b/backend/src/main/java/edu/duke/bookpublishing/common/SortUtils.java
@@ -22,6 +22,10 @@ public final class SortUtils {
           (directions != null && i < directions.size())
               ? Sort.Direction.fromString(directions.get(i))
               : Sort.Direction.ASC;
+      // Req 3.1.1: sorting by original revenue groups by currency first
+      if ("originalPublisherRevenue".equals(fields.get(i))) {
+        orders.add(new Sort.Order(dir, "saleCurrency"));
+      }
       orders.add(new Sort.Order(dir, fields.get(i)));
     }
     return Sort.by(orders);


### PR DESCRIPTION
## Summary
Req 3.1.1 specifies that sorting by publisher revenue in original currency should sort by currency type first, then by amount. Previously, sorting by `originalPublisherRevenue` sorted purely by the numeric value, mixing currencies together.

## Files changed
- **SortUtils.java** — when sort field is `originalPublisherRevenue`, prepend `saleCurrency` as a sort key with the same direction. 4 lines added.