### PR TITLE
fix: null-safe quantity in computePublisherRevenue

### DIFF
--- a/frontend/src/utils/royalty.ts
+++ b/frontend/src/utils/royalty.ts
@@ -21,10 +21,11 @@ export function computePublisherRevenue(
   saleSource: 'HAND_SOLD' | 'DISTRIBUTOR',
   coverPrice: number,
   printCost: number,
-  quantity: number,
+  quantity: number | null,
   distributorRevenue: number | null,
 ): number | null {
   if (saleSource === 'DISTRIBUTOR') return distributorRevenue;
+  if (quantity == null) return null;
   return computeHandsoldRevenue(coverPrice, printCost, quantity);
 }
 


### PR DESCRIPTION
## Summary
`computePublisherRevenue` typed `quantity` as `number` but KU sales pass null (they have KENP instead). The function worked by accident because KU sales are always distributor (which returns early before touching quantity). This makes the type honest and returns null gracefully instead of risking a crash if the call pattern ever changes.

## Files changed
- **utils/royalty.ts** — `quantity: number` → `quantity: number | null`, null check before handsold computation. 2 lines changed.