### PR TITLE
Frontend paypal

### DIFF
--- a/frontend/src/features/authors/AuthorEdit.tsx
+++ b/frontend/src/features/authors/AuthorEdit.tsx
@@ -1,3 +1,9 @@
+import { AuthorsService, type AuthorResponse } from '@/api';
+import FullPageLoader from '@/components/FullPageLoader';
+import PageContainer from '@/components/PageContainer';
+import { useNotifications } from '@/hooks/useNotifications/useNotifications';
+import { getErrorMessage } from '@/utils/error';
+import { truncate } from '@/utils/formatting';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
@@ -7,13 +13,7 @@ import Stack from '@mui/material/Stack';
 import TextField from '@mui/material/TextField';
 import * as React from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { AuthorsService, type AuthorResponse } from '@/api';
-import FullPageLoader from '@/components/FullPageLoader';
-import { useNotifications } from '@/hooks/useNotifications/useNotifications';
-import PageContainer from '@/components/PageContainer';
-import { getErrorMessage } from '@/utils/error';
-import { truncate } from '@/utils/formatting';
-import { type AuthorFormState, validateAuthor } from './authorValidation';
+import { validateAuthor, type AuthorFormState } from './authorValidation';
 
 export default function AuthorEdit() {
   const { authorId } = useParams();
@@ -32,7 +32,13 @@ export default function AuthorEdit() {
     try {
       const authorData = await AuthorsService.getAuthorById(Number(authorId));
       setAuthor(authorData);
-      setForm({ name: authorData.name, email: authorData.email ?? '', errors: {} });
+      setForm({
+  name: authorData.name,
+  email: authorData.email ?? '',
+  paypalAccount: authorData.paypalAccount ?? '',
+  venmoAccount: authorData.venmoAccount ?? '',
+  errors: {},
+});
     } catch (loadError) {
       setError(getErrorMessage(loadError));
     } finally {
@@ -65,9 +71,11 @@ export default function AuthorEdit() {
       setIsSubmitting(true);
       try {
         await AuthorsService.updateAuthor(Number(authorId), {
-          name: form.name.trim(),
-          email: form.email.trim(),
-        });
+  name: form.name.trim(),
+  email: form.email.trim(),
+  paypalAccount: form.paypalAccount?.trim() || undefined,
+  venmoAccount: form.venmoAccount?.trim() || undefined,
+});
         notifications.show('Author updated successfully.', {
           severity: 'success',
           autoHideDuration: 3000,
@@ -123,6 +131,26 @@ export default function AuthorEdit() {
                 fullWidth
               />
             </Grid>
+            <Grid size={{ xs: 12, sm: 6 }}>
+  <TextField
+    name="paypalAccount"
+    label="PayPal Account (paypal.me username)"
+    value={form.paypalAccount ?? ''}
+    onChange={handleChange}
+    helperText=" "
+    fullWidth
+  />
+</Grid>
+<Grid size={{ xs: 12, sm: 6 }}>
+  <TextField
+    name="venmoAccount"
+    label="Venmo Account"
+    value={form.venmoAccount ?? ''}
+    onChange={handleChange}
+    helperText=" "
+    fullWidth
+  />
+</Grid>
           </Grid>
 
           <Stack direction="row" spacing={2} justifyContent="space-between">

--- a/frontend/src/features/authors/AuthorEdit.tsx
+++ b/frontend/src/features/authors/AuthorEdit.tsx
@@ -33,12 +33,12 @@ export default function AuthorEdit() {
       const authorData = await AuthorsService.getAuthorById(Number(authorId));
       setAuthor(authorData);
       setForm({
-  name: authorData.name,
-  email: authorData.email ?? '',
-  paypalAccount: authorData.paypalAccount ?? '',
-  venmoAccount: authorData.venmoAccount ?? '',
-  errors: {},
-});
+        name: authorData.name,
+        email: authorData.email ?? '',
+        paypalAccount: authorData.paypalAccount ?? '',
+        venmoAccount: authorData.venmoAccount ?? '',
+        errors: {},
+      });
     } catch (loadError) {
       setError(getErrorMessage(loadError));
     } finally {
@@ -71,11 +71,11 @@ export default function AuthorEdit() {
       setIsSubmitting(true);
       try {
         await AuthorsService.updateAuthor(Number(authorId), {
-  name: form.name.trim(),
-  email: form.email.trim(),
-  paypalAccount: form.paypalAccount?.trim() || undefined,
-  venmoAccount: form.venmoAccount?.trim() || undefined,
-});
+          name: form.name.trim(),
+          email: form.email.trim(),
+          paypalAccount: form.paypalAccount?.trim() || undefined,
+          venmoAccount: form.venmoAccount?.trim() || undefined,
+        });
         notifications.show('Author updated successfully.', {
           severity: 'success',
           autoHideDuration: 3000,
@@ -132,25 +132,25 @@ export default function AuthorEdit() {
               />
             </Grid>
             <Grid size={{ xs: 12, sm: 6 }}>
-  <TextField
-    name="paypalAccount"
-    label="PayPal Account (paypal.me username)"
-    value={form.paypalAccount ?? ''}
-    onChange={handleChange}
-    helperText=" "
-    fullWidth
-  />
-</Grid>
-<Grid size={{ xs: 12, sm: 6 }}>
-  <TextField
-    name="venmoAccount"
-    label="Venmo Account"
-    value={form.venmoAccount ?? ''}
-    onChange={handleChange}
-    helperText=" "
-    fullWidth
-  />
-</Grid>
+              <TextField
+                name="paypalAccount"
+                label="PayPal Account (paypal.me username)"
+                value={form.paypalAccount ?? ''}
+                onChange={handleChange}
+                helperText=" "
+                fullWidth
+              />
+            </Grid>
+            <Grid size={{ xs: 12, sm: 6 }}>
+              <TextField
+                name="venmoAccount"
+                label="Venmo Account"
+                value={form.venmoAccount ?? ''}
+                onChange={handleChange}
+                helperText=" "
+                fullWidth
+              />
+            </Grid>
           </Grid>
 
           <Stack direction="row" spacing={2} justifyContent="space-between">

--- a/frontend/src/features/authors/AuthorPayments.tsx
+++ b/frontend/src/features/authors/AuthorPayments.tsx
@@ -360,7 +360,10 @@ export default function AuthorPayments() {
                           </div>
                         </Tooltip>
                         {authorInfo?.paypalAccount && unpaidTotal > 0 && (
-                          <Tooltip title={`Pay via PayPal: ${formatCurrency(unpaidTotal)}`} placement="bottom">
+                          <Tooltip
+                            title={`Pay via PayPal: ${formatCurrency(unpaidTotal)}`}
+                            placement="bottom"
+                          >
                             <IconButton
                               size="small"
                               component="a"
@@ -379,7 +382,10 @@ export default function AuthorPayments() {
                           </Tooltip>
                         )}
                         {authorInfo?.venmoAccount && unpaidTotal > 0 && (
-                          <Tooltip title={`Pay via Venmo: ${formatCurrency(unpaidTotal)}`} placement="bottom">
+                          <Tooltip
+                            title={`Pay via Venmo: ${formatCurrency(unpaidTotal)}`}
+                            placement="bottom"
+                          >
                             <IconButton
                               size="small"
                               component="a"

--- a/frontend/src/features/authors/AuthorPayments.tsx
+++ b/frontend/src/features/authors/AuthorPayments.tsx
@@ -79,11 +79,12 @@ export default function AuthorPayments() {
     setPage(0);
   }, [debouncedQuery]);
 
+  // Load all authors once so we can look up paypalAccount/venmoAccount by authorId
   React.useEffect(() => {
     let mounted = true;
     void (async () => {
       try {
-        const response = await BooksService.searchAuthors(debouncedQuery || undefined, 0, 25, true);
+        const response = await BooksService.searchAuthors(undefined, 0, 1000, true);
         if (mounted) setAuthorOptions(response.content ?? []);
       } catch {
         if (mounted) setAuthorOptions([]);
@@ -92,7 +93,7 @@ export default function AuthorPayments() {
     return () => {
       mounted = false;
     };
-  }, [debouncedQuery]);
+  }, []);
 
   // fetch grouped author payments from backend
   const loadGroups = React.useCallback(async () => {
@@ -101,7 +102,6 @@ export default function AuthorPayments() {
 
     try {
       const sizeToUse = showAll ? 1000 : pageSize;
-      // getAuthorPayments(page, size, showAll, startDate?, endDate?, query?)
       const response = await SalesService.getAuthorPayments(
         showAll ? 0 : page,
         sizeToUse,
@@ -306,6 +306,7 @@ export default function AuthorPayments() {
           <Box>
             {groups.map((group, idx) => {
               const unpaidTotal = group.unpaidTotal ?? 0;
+              const authorInfo = authorOptions.find((a) => a.id === group.authorId);
               return (
                 <Accordion
                   key={`${group.author}-${idx}`}
@@ -358,6 +359,44 @@ export default function AuthorPayments() {
                             </Button>
                           </div>
                         </Tooltip>
+                        {authorInfo?.paypalAccount && unpaidTotal > 0 && (
+                          <Tooltip title={`Pay via PayPal: ${formatCurrency(unpaidTotal)}`} placement="bottom">
+                            <IconButton
+                              size="small"
+                              component="a"
+                              href={`https://paypal.me/${authorInfo.paypalAccount}/${unpaidTotal.toFixed(2)}`}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              onClick={(e) => e.stopPropagation()}
+                            >
+                              <Box
+                                component="img"
+                                src="https://www.paypalobjects.com/webstatic/icon/pp258.png"
+                                alt="PayPal"
+                                sx={{ width: 24, height: 24, borderRadius: 1 }}
+                              />
+                            </IconButton>
+                          </Tooltip>
+                        )}
+                        {authorInfo?.venmoAccount && unpaidTotal > 0 && (
+                          <Tooltip title={`Pay via Venmo: ${formatCurrency(unpaidTotal)}`} placement="bottom">
+                            <IconButton
+                              size="small"
+                              component="a"
+                              href={`https://venmo.com/${authorInfo.venmoAccount}?amount=${unpaidTotal.toFixed(2)}&note=Author+royalty`}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              onClick={(e) => e.stopPropagation()}
+                            >
+                              <Box
+                                component="img"
+                                src="https://venmo.com/favicon.ico"
+                                alt="Venmo"
+                                sx={{ width: 24, height: 24, borderRadius: 1 }}
+                              />
+                            </IconButton>
+                          </Tooltip>
+                        )}
                       </Stack>
                     </Stack>
                   </AccordionSummary>

--- a/frontend/src/features/authors/AuthorShow.tsx
+++ b/frontend/src/features/authors/AuthorShow.tsx
@@ -184,6 +184,26 @@ export default function AuthorShow() {
             </Typography>
           </Paper>
         </Grid>
+        {author.paypalAccount && (
+          <Grid size={{ xs: 12, sm: 6 }}>
+            <Paper sx={{ px: 2, py: 1 }}>
+              <Typography variant="overline">PayPal</Typography>
+              <Typography variant="body1" sx={{ mb: 1 }}>
+                {author.paypalAccount}
+              </Typography>
+            </Paper>
+          </Grid>
+        )}
+        {author.venmoAccount && (
+          <Grid size={{ xs: 12, sm: 6 }}>
+            <Paper sx={{ px: 2, py: 1 }}>
+              <Typography variant="overline">Venmo</Typography>
+              <Typography variant="body1" sx={{ mb: 1 }}>
+                {author.venmoAccount}
+              </Typography>
+            </Paper>
+          </Grid>
+        )}
       </Grid>
       <Box sx={{ mt: 3 }}>
         <Paper sx={{ p: 2 }}>

--- a/frontend/src/features/authors/authorValidation.ts
+++ b/frontend/src/features/authors/authorValidation.ts
@@ -3,6 +3,8 @@ const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@.]+$/;
 export interface AuthorFormState {
   name: string;
   email: string;
+  paypalAccount?: string;
+  venmoAccount?: string;
   errors: { name?: string; email?: string };
 }
 


### PR DESCRIPTION
- authorValidation.ts — add optional paypalAccount and venmoAccount fields to AuthorFormState interface so the form can hold these values
- AuthorEdit.tsx — load paypalAccount and venmoAccount from existing AuthorResponse in loadData, wire both fields through handleSubmit to the existing updateAuthor endpoint, and add two new text input fields to the form grid
- AuthorPayments.tsx — look up author payment accounts from the existing authorOptions state using authorId, change author fetch to load all authors (1000) instead of 25 so payment accounts are reliably available, and add PayPal and Venmo icon buttons next to the Pay button that open pre-filled payment links in a new tab when the author has those accounts set and has unpaid royalties