### PR TITLE
Projected Sales

### DIFF
--- a/backend/src/main/java/edu/duke/bookpublishing/author/Author.java
+++ b/backend/src/main/java/edu/duke/bookpublishing/author/Author.java
@@ -1,10 +1,20 @@
 package edu.duke.bookpublishing.author;
 
 import edu.duke.bookpublishing.common.StringUtils;
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
 import jakarta.validation.constraints.Email;
 import java.math.BigDecimal;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Formula;
 
 @Entity
@@ -35,15 +45,15 @@ public class Author {
   private Long bookCount;
 
   @Formula(
-      "(SELECT COALESCE(SUM(s.author_royalty), 0) FROM sales s JOIN books b ON s.book_id = b.id WHERE b.author_id = id)")
+      "(SELECT COALESCE(SUM(s.author_royalty), 0) FROM sales s JOIN books b ON s.book_id = b.id WHERE b.author_id = id AND b.released = true)")
   private BigDecimal totalRoyalty;
 
   @Formula(
-      "(SELECT COALESCE(SUM(s.author_royalty), 0) FROM sales s JOIN books b ON s.book_id = b.id WHERE b.author_id = id AND s.has_author_been_paid = true)")
+      "(SELECT COALESCE(SUM(s.author_royalty), 0) FROM sales s JOIN books b ON s.book_id = b.id WHERE b.author_id = id AND b.released = true AND s.has_author_been_paid = true)")
   private BigDecimal paidRoyalty;
 
   @Formula(
-      "(SELECT COALESCE(SUM(s.author_royalty), 0) FROM sales s JOIN books b ON s.book_id = b.id WHERE b.author_id = id AND s.has_author_been_paid = false)")
+      "(SELECT COALESCE(SUM(s.author_royalty), 0) FROM sales s JOIN books b ON s.book_id = b.id WHERE b.author_id = id AND b.released = true AND s.has_author_been_paid = false)")
   private BigDecimal unpaidRoyalty;
 
   @PrePersist

--- a/backend/src/main/java/edu/duke/bookpublishing/sales/Sale.java
+++ b/backend/src/main/java/edu/duke/bookpublishing/sales/Sale.java
@@ -26,6 +26,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.Formula;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 
@@ -87,16 +88,16 @@ public class Sale {
   private Currency saleCurrency;
 
   /*
-    Publisher revenue in the original currency in which the sale was made.
-  */
+   * Publisher revenue in the original currency in which the sale was made.
+   */
   @PositiveOrZero
   @Column(name = "usd_publisher_revenue", nullable = false, precision = 19, scale = 2)
   private BigDecimal originalPublisherRevenue;
 
   /*
-    USD Publisher Revenue, the source of truth for all revenue calculations.
-    If sale was made in other currency, this is the converted amount
-  */
+   * USD Publisher Revenue, the source of truth for all revenue calculations. If sale was made in
+   * other currency, this is the converted amount
+   */
   @PositiveOrZero
   @Column(name = "publisher_revenue", nullable = false, precision = 19, scale = 2)
   private BigDecimal publisherRevenue;
@@ -109,6 +110,10 @@ public class Sale {
 
   @Column(name = "comment", length = 256)
   private String comment;
+
+  @Formula(
+      "CASE WHEN (SELECT b.released FROM books b WHERE b.id = book_id) = false THEN true ELSE false END")
+  private Boolean isProjected;
 
   @AssertTrue(
       message = "KINDLE_UNLIMITED requires KENP and no quantity; print/ebook require quantity")

--- a/backend/src/main/java/edu/duke/bookpublishing/sales/SaleController.java
+++ b/backend/src/main/java/edu/duke/bookpublishing/sales/SaleController.java
@@ -74,6 +74,7 @@ public class SaleController {
       @RequestParam(required = false) SaleSource saleSource,
       @RequestParam(required = false) SaleDistributor distributor,
       @RequestParam(required = false) SaleFormat format,
+      @RequestParam(required = false) Boolean isProjected,
       @RequestParam(required = false) String query,
       @RequestParam(required = false) Long bookId) {
 
@@ -82,14 +83,32 @@ public class SaleController {
     if (showAll) {
       List<Sale> sales =
           saleService.getAllSales(
-              startDate, endDate, authorId, bookId, saleSource, distributor, format, query, sort);
+              startDate,
+              endDate,
+              authorId,
+              bookId,
+              saleSource,
+              distributor,
+              format,
+              isProjected,
+              query,
+              sort);
       return PagedResponse.unpaged(sales, SaleResponse::from);
     }
 
     Pageable pageable = PageRequest.of(page, size, sort);
     Page<Sale> sales =
         saleService.getPagedSales(
-            startDate, endDate, authorId, bookId, saleSource, distributor, format, query, pageable);
+            startDate,
+            endDate,
+            authorId,
+            bookId,
+            saleSource,
+            distributor,
+            format,
+            isProjected,
+            query,
+            pageable);
     return PagedResponse.paged(sales, SaleResponse::from);
   }
 
@@ -104,6 +123,7 @@ public class SaleController {
       @RequestParam(required = false) SaleSource saleSource,
       @RequestParam(required = false) SaleDistributor distributor,
       @RequestParam(required = false) SaleFormat format,
+      @RequestParam(required = false) Boolean isProjected,
       @RequestParam(required = false) String query,
       @RequestParam(required = false) Long bookId,
       HttpServletResponse response)
@@ -118,6 +138,7 @@ public class SaleController {
             saleSource,
             distributor,
             format,
+            isProjected,
             query,
             Sort.unsorted());
 

--- a/backend/src/main/java/edu/duke/bookpublishing/sales/SaleRepository.java
+++ b/backend/src/main/java/edu/duke/bookpublishing/sales/SaleRepository.java
@@ -21,20 +21,22 @@ public interface SaleRepository extends JpaRepository<Sale, Long>, JpaSpecificat
 
   @Query(
       """
-            select coalesce(sum(s.quantitySold), 0)
-            from Sale s
-            where s.book.id = :bookId
-            """)
+              select coalesce(sum(s.quantitySold), 0)
+              from Sale s
+              where s.book.id = :bookId
+            and s.book.released = true
+              """)
   Long totalUnitsSoldByBook(Long bookId);
 
   // ---- Requirement 2.2 Book Detail ----
   // 1) Total Publisher revenue for a book
   @Query(
       """
-            select coalesce(sum(s.publisherRevenue), 0)
-            from Sale s
-            where s.book.id = :bookId
-            """)
+              select coalesce(sum(s.publisherRevenue), 0)
+              from Sale s
+              where s.book.id = :bookId
+            and s.book.released = true
+              """)
   BigDecimal totalPublisherRevenueByBook(Long bookId);
 
   // 2) Total UNPAID author royalty for a book
@@ -43,6 +45,7 @@ public interface SaleRepository extends JpaRepository<Sale, Long>, JpaSpecificat
             select coalesce(sum(s.authorRoyalty), 0)
             from Sale s
             where s.book.id = :bookId
+              and s.book.released = true
               and s.hasAuthorBeenPaid = false
             """)
   BigDecimal totalUnpaidAuthorRoyaltyByBook(Long bookId);
@@ -53,6 +56,7 @@ public interface SaleRepository extends JpaRepository<Sale, Long>, JpaSpecificat
             select coalesce(sum(s.authorRoyalty), 0)
             from Sale s
             where s.book.id = :bookId
+              and s.book.released = true
               and s.hasAuthorBeenPaid = true
             """)
   BigDecimal totalPaidAuthorRoyaltyByBook(Long bookId);
@@ -60,10 +64,11 @@ public interface SaleRepository extends JpaRepository<Sale, Long>, JpaSpecificat
   // 4) Total (paid + unpaid) author royalty for a book
   @Query(
       """
-            select coalesce(sum(s.authorRoyalty), 0)
-            from Sale s
-            where s.book.id = :bookId
-            """)
+              select coalesce(sum(s.authorRoyalty), 0)
+              from Sale s
+              where s.book.id = :bookId
+            and s.book.released = true
+              """)
   BigDecimal totalAuthorRoyaltyByBook(Long bookId);
 
   // ---- Requirement 3.2 Author Payments ----

--- a/backend/src/main/java/edu/duke/bookpublishing/sales/SaleRepository.java
+++ b/backend/src/main/java/edu/duke/bookpublishing/sales/SaleRepository.java
@@ -21,60 +21,61 @@ public interface SaleRepository extends JpaRepository<Sale, Long>, JpaSpecificat
 
   @Query(
       """
-      select coalesce(sum(s.quantitySold), 0)
-      from Sale s
-      where s.book.id = :bookId
-      """)
+            select coalesce(sum(s.quantitySold), 0)
+            from Sale s
+            where s.book.id = :bookId
+            """)
   Long totalUnitsSoldByBook(Long bookId);
 
   // ---- Requirement 2.2 Book Detail ----
   // 1) Total Publisher revenue for a book
   @Query(
       """
-      select coalesce(sum(s.publisherRevenue), 0)
-      from Sale s
-      where s.book.id = :bookId
-      """)
+            select coalesce(sum(s.publisherRevenue), 0)
+            from Sale s
+            where s.book.id = :bookId
+            """)
   BigDecimal totalPublisherRevenueByBook(Long bookId);
 
   // 2) Total UNPAID author royalty for a book
   @Query(
       """
-      select coalesce(sum(s.authorRoyalty), 0)
-      from Sale s
-      where s.book.id = :bookId
-        and s.hasAuthorBeenPaid = false
-      """)
+            select coalesce(sum(s.authorRoyalty), 0)
+            from Sale s
+            where s.book.id = :bookId
+              and s.hasAuthorBeenPaid = false
+            """)
   BigDecimal totalUnpaidAuthorRoyaltyByBook(Long bookId);
 
   // 3) Total PAID author royalty for a book
   @Query(
       """
-      select coalesce(sum(s.authorRoyalty), 0)
-      from Sale s
-      where s.book.id = :bookId
-        and s.hasAuthorBeenPaid = true
-      """)
+            select coalesce(sum(s.authorRoyalty), 0)
+            from Sale s
+            where s.book.id = :bookId
+              and s.hasAuthorBeenPaid = true
+            """)
   BigDecimal totalPaidAuthorRoyaltyByBook(Long bookId);
 
   // 4) Total (paid + unpaid) author royalty for a book
   @Query(
       """
-      select coalesce(sum(s.authorRoyalty), 0)
-      from Sale s
-      where s.book.id = :bookId
-      """)
+            select coalesce(sum(s.authorRoyalty), 0)
+            from Sale s
+            where s.book.id = :bookId
+            """)
   BigDecimal totalAuthorRoyaltyByBook(Long bookId);
 
   // ---- Requirement 3.2 Author Payments ----
   @Modifying(clearAutomatically = true)
   @Query(
       """
-          update Sale s
-          set s.hasAuthorBeenPaid = true
-          where s.hasAuthorBeenPaid = false
-            and s.book.author.id = :authorId
-      """)
+                update Sale s
+                set s.hasAuthorBeenPaid = true
+                where s.hasAuthorBeenPaid = false
+                  and s.book.author.id = :authorId
+              and s.book.released = true
+            """)
   int markAllPaidByAuthorId(@Param("authorId") Long authorId);
 
   @Query("select s from Sale s join fetch s.book where s.book.author.id = :authorId")

--- a/backend/src/main/java/edu/duke/bookpublishing/sales/SaleService.java
+++ b/backend/src/main/java/edu/duke/bookpublishing/sales/SaleService.java
@@ -94,11 +94,20 @@ public class SaleService {
       SaleSource saleSource,
       SaleDistributor distributor,
       SaleFormat format,
+      Boolean isProjected,
       String query,
       Sort sort) {
     Specification<Sale> spec =
         buildSaleSpecification(
-            startDate, endDate, authorId, bookId, saleSource, distributor, format, query);
+            startDate,
+            endDate,
+            authorId,
+            bookId,
+            saleSource,
+            distributor,
+            format,
+            isProjected,
+            query);
     return saleRepository.findAll(spec, sort);
   }
 
@@ -110,11 +119,20 @@ public class SaleService {
       SaleSource saleSource,
       SaleDistributor distributor,
       SaleFormat format,
+      Boolean isProjected,
       String query,
       Pageable pageable) {
     Specification<Sale> spec =
         buildSaleSpecification(
-            startDate, endDate, authorId, bookId, saleSource, distributor, format, query);
+            startDate,
+            endDate,
+            authorId,
+            bookId,
+            saleSource,
+            distributor,
+            format,
+            isProjected,
+            query);
     return saleRepository.findAll(spec, pageable);
   }
 
@@ -126,6 +144,7 @@ public class SaleService {
       SaleSource saleSource,
       SaleDistributor distributor,
       SaleFormat format,
+      Boolean isProjected,
       String query) {
     Specification<Sale> spec = Specification.where(null);
 
@@ -153,6 +172,10 @@ public class SaleService {
 
     if (format != null) {
       spec = spec.and(SaleSpecifications.byFormat(format));
+    }
+
+    if (isProjected != null) {
+      spec = spec.and(SaleSpecifications.isProjected(isProjected));
     }
 
     if (query != null && !query.isBlank()) {
@@ -201,6 +224,7 @@ public class SaleService {
     List<AuthorPaymentGroupResponse> groups = new ArrayList<>();
     for (Map.Entry<Long, List<Sale>> entry : grouped.entrySet()) {
       BigDecimal unpaidTotal = BigDecimal.ZERO;
+      BigDecimal projectedTotal = BigDecimal.ZERO;
       List<AuthorPaymentSaleResponse> saleRows = new ArrayList<>();
       String authorName = null;
 
@@ -209,12 +233,22 @@ public class SaleService {
         if (authorName == null) {
           authorName = sale.getBook().getAuthor().getName();
         }
-        if (!Boolean.TRUE.equals(sale.getHasAuthorBeenPaid())) {
-          unpaidTotal = unpaidTotal.add(sale.getAuthorRoyalty());
+        // Exclude projected sales from unpaid total
+        boolean isProjected = !sale.getBook().getReleased();
+        if (isProjected) {
+          if (!Boolean.TRUE.equals(sale.getHasAuthorBeenPaid())) {
+            projectedTotal = projectedTotal.add(sale.getAuthorRoyalty());
+          }
+        } else {
+          if (!Boolean.TRUE.equals(sale.getHasAuthorBeenPaid())) {
+            unpaidTotal = unpaidTotal.add(sale.getAuthorRoyalty());
+          }
         }
       }
 
-      groups.add(new AuthorPaymentGroupResponse(entry.getKey(), authorName, unpaidTotal, saleRows));
+      groups.add(
+          new AuthorPaymentGroupResponse(
+              entry.getKey(), authorName, unpaidTotal, projectedTotal, saleRows));
     }
 
     return groups;

--- a/backend/src/main/java/edu/duke/bookpublishing/sales/SaleService.java
+++ b/backend/src/main/java/edu/duke/bookpublishing/sales/SaleService.java
@@ -355,8 +355,11 @@ public class SaleService {
             .map(Author::getName)
             .orElseThrow(() -> new NotFoundException("Author not found"));
 
-    // Get all sales for this author
-    List<Sale> allSales = saleRepository.findAllByAuthorId(authorId);
+    // Get all non-projected sales for this author
+    List<Sale> allSales =
+        saleRepository.findAllByAuthorId(authorId).stream()
+            .filter(sale -> !isUnreleased(sale.getBook()))
+            .toList();
 
     // Generate quarter sections, conditionally including quarters with no sales
     List<QuarterSection> sections = new ArrayList<>();
@@ -951,11 +954,7 @@ public class SaleService {
   }
 
   private boolean isUnreleased(Book book) {
-    if (book.getPublicationYear() == null || book.getPublicationMonth() == null) {
-      return true;
-    }
-    YearMonth publication = YearMonth.of(book.getPublicationYear(), book.getPublicationMonth());
-    return publication.isAfter(YearMonth.now());
+    return !Boolean.TRUE.equals(book.getReleased());
   }
 
   private String bookDisplayName(Book book) {

--- a/backend/src/main/java/edu/duke/bookpublishing/sales/SaleSpecifications.java
+++ b/backend/src/main/java/edu/duke/bookpublishing/sales/SaleSpecifications.java
@@ -44,6 +44,14 @@ public final class SaleSpecifications {
     return (root, query, cb) -> cb.equal(root.get("format"), format);
   }
 
+  /** Filters sales by projected status (true = projected/unreleased, false = actual/released). */
+  public static Specification<Sale> isProjected(Boolean isProjected) {
+    if (isProjected == null) {
+      return (root, query, cb) -> cb.conjunction();
+    }
+    return (root, query, cb) -> cb.equal(root.get("book").get("released"), !isProjected);
+  }
+
   public static Specification<Sale> withinDateRange(LocalDate startDate, LocalDate endDate) {
     return (root, query, cb) -> {
       var predicate = cb.conjunction(); // "true" starting point

--- a/backend/src/main/java/edu/duke/bookpublishing/sales/dto/AuthorPaymentGroupResponse.java
+++ b/backend/src/main/java/edu/duke/bookpublishing/sales/dto/AuthorPaymentGroupResponse.java
@@ -13,5 +13,10 @@ public record AuthorPaymentGroupResponse(
     @Schema(description = "Author name", requiredMode = REQUIRED) String author,
     @Schema(description = "Total unpaid author royalty for this author", requiredMode = REQUIRED)
         BigDecimal unpaidTotal,
+    @Schema(
+            description =
+                "Total unpaid projected author royalty for this author (not eligible for payment)",
+            requiredMode = REQUIRED)
+        BigDecimal projectedUnpaidTotal,
     @Schema(description = "Sales rows for this author", requiredMode = REQUIRED)
         List<AuthorPaymentSaleResponse> sales) {}

--- a/backend/src/main/java/edu/duke/bookpublishing/sales/dto/AuthorPaymentSaleResponse.java
+++ b/backend/src/main/java/edu/duke/bookpublishing/sales/dto/AuthorPaymentSaleResponse.java
@@ -24,7 +24,11 @@ public record AuthorPaymentSaleResponse(
     @Schema(
             description = "Indicates whether the author has been paid or not",
             requiredMode = REQUIRED)
-        boolean hasAuthorBeenPaid) {
+        boolean hasAuthorBeenPaid,
+    @Schema(
+            description = "Indicates whether this is a projected sale (book not yet released)",
+            requiredMode = REQUIRED)
+        boolean isProjected) {
 
   public static AuthorPaymentSaleResponse from(Sale sale) {
     return new AuthorPaymentSaleResponse(
@@ -37,6 +41,7 @@ public record AuthorPaymentSaleResponse(
         sale.getQuantitySold(),
         sale.getPublisherRevenue(),
         sale.getAuthorRoyalty(),
-        sale.getHasAuthorBeenPaid());
+        sale.getHasAuthorBeenPaid(),
+        !Boolean.TRUE.equals(sale.getBook().getReleased()));
   }
 }

--- a/backend/src/main/java/edu/duke/bookpublishing/sales/dto/SaleResponse.java
+++ b/backend/src/main/java/edu/duke/bookpublishing/sales/dto/SaleResponse.java
@@ -52,7 +52,12 @@ public record SaleResponse(
             description = "Indicates whether the author has been paid or not",
             requiredMode = REQUIRED)
         boolean hasAuthorBeenPaid,
-    @Schema(description = "Optional comment") String comment) {
+    @Schema(description = "Optional comment") String comment,
+    @Schema(
+            description =
+                "True if this sale is for an unreleased book (projected/not yet eligible for payment)",
+            requiredMode = REQUIRED)
+        Boolean isProjected) {
 
   public static SaleResponse from(Sale sale) {
     return new SaleResponse(
@@ -73,6 +78,7 @@ public record SaleResponse(
         sale.getPublisherRevenue(),
         sale.getAuthorRoyalty(),
         sale.getHasAuthorBeenPaid(),
-        sale.getComment());
+        sale.getComment(),
+        !sale.getBook().getReleased());
   }
 }

--- a/backend/src/test/java/edu/duke/bookpublishing/sales/SaleServiceTest.java
+++ b/backend/src/test/java/edu/duke/bookpublishing/sales/SaleServiceTest.java
@@ -147,7 +147,7 @@ class SaleServiceTest {
   @Test
   void getAllSalesWithoutFiltersUsesSpecification() {
     Sort sort = Sort.by("saleYear").descending();
-    saleService.getAllSales(null, null, null, null, null, null, null, null, sort);
+    saleService.getAllSales(null, null, null, null, null, null, null, null, null, sort);
     verify(saleRepository, times(1))
         .findAll(org.mockito.ArgumentMatchers.<Specification<Sale>>any(), any(Sort.class));
   }
@@ -157,7 +157,7 @@ class SaleServiceTest {
     LocalDate startDate = LocalDate.of(2024, 1, 1);
     LocalDate endDate = LocalDate.of(2024, 12, 31);
     Sort sort = Sort.by("saleYear").descending();
-    saleService.getAllSales(startDate, endDate, null, null, null, null, null, null, sort);
+    saleService.getAllSales(startDate, endDate, null, null, null, null, null, null, null, sort);
     verify(saleRepository, times(1))
         .findAll(org.mockito.ArgumentMatchers.<Specification<Sale>>any(), any(Sort.class));
   }
@@ -165,7 +165,7 @@ class SaleServiceTest {
   @Test
   void getAllSalesWithQueryUsesSpecification() {
     Sort sort = Sort.by("saleYear").descending();
-    saleService.getAllSales(null, null, null, null, null, null, null, "test query", sort);
+    saleService.getAllSales(null, null, null, null, null, null, null, null, "test query", sort);
     verify(saleRepository, times(1))
         .findAll(org.mockito.ArgumentMatchers.<Specification<Sale>>any(), any(Sort.class));
   }
@@ -173,7 +173,7 @@ class SaleServiceTest {
   @Test
   void getPagedSalesWithoutFiltersUsesSpecification() {
     Pageable pageable = mock(Pageable.class);
-    saleService.getPagedSales(null, null, null, null, null, null, null, null, pageable);
+    saleService.getPagedSales(null, null, null, null, null, null, null, null, null, pageable);
     verify(saleRepository, times(1))
         .findAll(org.mockito.ArgumentMatchers.<Specification<Sale>>any(), any(Pageable.class));
   }
@@ -183,7 +183,8 @@ class SaleServiceTest {
     Pageable pageable = mock(Pageable.class);
     LocalDate startDate = LocalDate.of(2024, 1, 1);
     LocalDate endDate = LocalDate.of(2024, 12, 31);
-    saleService.getPagedSales(startDate, endDate, null, null, null, null, null, null, pageable);
+    saleService.getPagedSales(
+        startDate, endDate, null, null, null, null, null, null, null, pageable);
     verify(saleRepository, times(1))
         .findAll(org.mockito.ArgumentMatchers.<Specification<Sale>>any(), any(Pageable.class));
   }
@@ -191,7 +192,8 @@ class SaleServiceTest {
   @Test
   void getPagedSalesWithQueryUsesSpecification() {
     Pageable pageable = mock(Pageable.class);
-    saleService.getPagedSales(null, null, null, null, null, null, null, "test query", pageable);
+    saleService.getPagedSales(
+        null, null, null, null, null, null, null, null, "test query", pageable);
     verify(saleRepository, times(1))
         .findAll(org.mockito.ArgumentMatchers.<Specification<Sale>>any(), any(Pageable.class));
   }

--- a/frontend/src/api/generated/models/AuthorPaymentGroupResponse.ts
+++ b/frontend/src/api/generated/models/AuthorPaymentGroupResponse.ts
@@ -20,6 +20,10 @@ export type AuthorPaymentGroupResponse = {
      */
     unpaidTotal: number;
     /**
+     * Total unpaid projected author royalty for this author (not eligible for payment)
+     */
+    projectedUnpaidTotal: number;
+    /**
      * Sales rows for this author
      */
     sales: Array<AuthorPaymentSaleResponse>;

--- a/frontend/src/api/generated/models/AuthorPaymentSaleResponse.ts
+++ b/frontend/src/api/generated/models/AuthorPaymentSaleResponse.ts
@@ -46,5 +46,9 @@ export type AuthorPaymentSaleResponse = {
      * Indicates whether the author has been paid or not
      */
     hasAuthorBeenPaid: boolean;
+    /**
+     * Indicates whether this is a projected sale (book not yet released)
+     */
+    isProjected: boolean;
 };
 

--- a/frontend/src/api/generated/models/SaleResponse.ts
+++ b/frontend/src/api/generated/models/SaleResponse.ts
@@ -78,6 +78,10 @@ export type SaleResponse = {
      * Optional comment
      */
     comment?: string;
+    /**
+     * True if this sale is for an unreleased book (projected/not yet eligible for payment)
+     */
+    isProjected: boolean;
 };
 export namespace SaleResponse {
     /**

--- a/frontend/src/api/generated/services/SalesService.ts
+++ b/frontend/src/api/generated/services/SalesService.ts
@@ -99,6 +99,7 @@ export class SalesService {
      * @param saleSource
      * @param distributor
      * @param format
+     * @param isProjected
      * @param query
      * @param bookId
      * @returns PagedResponseSaleResponse OK
@@ -116,6 +117,7 @@ export class SalesService {
         saleSource?: 'DISTRIBUTOR' | 'HAND_SOLD' | 'KICKSTARTER',
         distributor?: 'INGRAM_SPARK' | 'AMAZON' | 'OTHER',
         format?: 'PRINT' | 'EBOOK' | 'KINDLE_UNLIMITED',
+        isProjected?: boolean,
         query?: string,
         bookId?: number,
     ): CancelablePromise<PagedResponseSaleResponse> {
@@ -134,6 +136,7 @@ export class SalesService {
                 'saleSource': saleSource,
                 'distributor': distributor,
                 'format': format,
+                'isProjected': isProjected,
                 'query': query,
                 'bookId': bookId,
             },
@@ -274,6 +277,7 @@ export class SalesService {
      * @param saleSource
      * @param distributor
      * @param format
+     * @param isProjected
      * @param query
      * @param bookId
      * @returns any OK
@@ -286,6 +290,7 @@ export class SalesService {
         saleSource?: 'DISTRIBUTOR' | 'HAND_SOLD' | 'KICKSTARTER',
         distributor?: 'INGRAM_SPARK' | 'AMAZON' | 'OTHER',
         format?: 'PRINT' | 'EBOOK' | 'KINDLE_UNLIMITED',
+        isProjected?: boolean,
         query?: string,
         bookId?: number,
     ): CancelablePromise<any> {
@@ -299,6 +304,7 @@ export class SalesService {
                 'saleSource': saleSource,
                 'distributor': distributor,
                 'format': format,
+                'isProjected': isProjected,
                 'query': query,
                 'bookId': bookId,
             },

--- a/frontend/src/features/authors/AuthorList.tsx
+++ b/frontend/src/features/authors/AuthorList.tsx
@@ -21,6 +21,7 @@ import InputAdornment from '@mui/material/InputAdornment';
 import Stack from '@mui/material/Stack';
 import TextField from '@mui/material/TextField';
 import Tooltip from '@mui/material/Tooltip';
+import Typography from '@mui/material/Typography';
 import {
   GridActionsCellItem,
   type GridColDef,
@@ -230,6 +231,9 @@ export default function AuthorList() {
         </Stack>
       }
     >
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+        Royalty totals exclude projected sales for unreleased books.
+      </Typography>
       <Box sx={{ flex: 1, width: '100%' }}>
         <StandardDataGrid
           rows={rows}

--- a/frontend/src/features/authors/AuthorPayments.tsx
+++ b/frontend/src/features/authors/AuthorPayments.tsx
@@ -117,11 +117,7 @@ export default function AuthorPayments() {
           if (yearDiff !== 0) return yearDiff;
           return b.saleMonth - a.saleMonth;
         });
-        const unpaidTotal = sales.reduce(
-          (sum, sale) => sum + (sale.hasAuthorBeenPaid ? 0 : sale.authorRoyalty),
-          0,
-        );
-        return { ...g, sales, unpaidTotal };
+        return { ...g, sales };
       });
 
       setGroups(normalized);
@@ -185,9 +181,11 @@ export default function AuthorPayments() {
 
   const handlePayAuthor = React.useCallback(
     async (group: AuthorPaymentGroupResponse) => {
-      const unpaidCount = group.sales.filter((sale) => !sale.hasAuthorBeenPaid).length;
+      const unpaidCount = group.sales.filter(
+        (sale) => !sale.hasAuthorBeenPaid && !sale.isProjected,
+      ).length;
       if (unpaidCount === 0) {
-        notifications.show('No unpaid records for this author', {
+        notifications.show('No non-projected unpaid records for this author', {
           severity: 'error',
           autoHideDuration: 3000,
         });
@@ -199,6 +197,8 @@ export default function AuthorPayments() {
         <>
           You are about to mark <strong>{group.author}</strong>&apos;s {unpaidCount} unpaid sale
           record(s) as paid. Total: <strong>{formatCurrency(unpaidTotal)}</strong>.
+          <br />
+          Projected sales are excluded and will remain unpaid until release.
         </>,
         { title: 'Confirm mark paid', okText: 'Confirm', severity: 'warning' },
       );
@@ -306,6 +306,7 @@ export default function AuthorPayments() {
           <Box>
             {groups.map((group, idx) => {
               const unpaidTotal = group.unpaidTotal ?? 0;
+              const projectedUnpaidTotal = group.projectedUnpaidTotal ?? 0;
               const authorInfo = authorOptions.find((a) => a.id === group.authorId);
               return (
                 <Accordion
@@ -340,6 +341,14 @@ export default function AuthorPayments() {
                           size="small"
                           variant={unpaidTotal > 0 ? 'outlined' : 'filled'}
                         />
+                        <Chip
+                          icon={<PendingIcon />}
+                          label={`Projected (Not Eligible): ${formatCurrency(projectedUnpaidTotal)}`}
+                          color="default"
+                          size="small"
+                          variant="outlined"
+                          sx={{ opacity: 0.8 }}
+                        />
                       </Stack>
 
                       <Stack direction="row" spacing={1} alignItems="center">
@@ -361,7 +370,7 @@ export default function AuthorPayments() {
                         </Tooltip>
                         {authorInfo?.paypalAccount && unpaidTotal > 0 && (
                           <Tooltip
-                            title={`Pay via PayPal: ${formatCurrency(unpaidTotal)}`}
+                            title={`Pay non-projected unpaid total via PayPal: ${formatCurrency(unpaidTotal)}`}
                             placement="bottom"
                           >
                             <IconButton
@@ -383,7 +392,7 @@ export default function AuthorPayments() {
                         )}
                         {authorInfo?.venmoAccount && unpaidTotal > 0 && (
                           <Tooltip
-                            title={`Pay via Venmo: ${formatCurrency(unpaidTotal)}`}
+                            title={`Pay non-projected unpaid total via Venmo: ${formatCurrency(unpaidTotal)}`}
                             placement="bottom"
                           >
                             <IconButton
@@ -425,7 +434,11 @@ export default function AuthorPayments() {
                             <TableRow
                               key={sale.id}
                               hover
-                              sx={{ cursor: 'pointer' }}
+                              sx={{
+                                cursor: 'pointer',
+                                opacity: sale.isProjected ? 0.55 : 1,
+                                bgcolor: sale.isProjected ? 'action.hover' : 'transparent',
+                              }}
                               onClick={(event) => handleSaleNavigate(sale.id, event)}
                               onAuxClick={(event) => handleSaleNavigate(sale.id, event)}
                             >
@@ -458,7 +471,17 @@ export default function AuthorPayments() {
                               </TableCell>
 
                               <TableCell>
-                                <PaidStatusChip paid={sale.hasAuthorBeenPaid} />
+                                <Stack direction="row" spacing={1} alignItems="center">
+                                  <PaidStatusChip paid={sale.hasAuthorBeenPaid} />
+                                  {sale.isProjected && (
+                                    <Chip
+                                      label="Projected"
+                                      size="small"
+                                      variant="outlined"
+                                      color="default"
+                                    />
+                                  )}
+                                </Stack>
                               </TableCell>
                             </TableRow>
                           ))}

--- a/frontend/src/features/authors/AuthorShow.tsx
+++ b/frontend/src/features/authors/AuthorShow.tsx
@@ -210,6 +210,9 @@ export default function AuthorShow() {
           <Typography variant="h6" sx={{ mb: 2 }}>
             Books
           </Typography>
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+            Royalty totals shown below exclude projected sales for unreleased books.
+          </Typography>
           {books.length === 0 ? (
             <Alert severity="info">No books found for this author.</Alert>
           ) : (
@@ -221,7 +224,7 @@ export default function AuthorShow() {
                     <TableCell>Series</TableCell>
                     <TableCell>Publication</TableCell>
                     <TableCell align="right">Distributor Royalty</TableCell>
-                    <TableCell align="right">Handsold Royalty</TableCell>
+                    <TableCell align="right">Handsold/Kickstarter Royalty</TableCell>
                     <TableCell align="right">Total Royalty</TableCell>
                     <TableCell align="right">Paid Royalty</TableCell>
                     <TableCell align="right">Unpaid Royalty</TableCell>

--- a/frontend/src/features/books/BookCreate.tsx
+++ b/frontend/src/features/books/BookCreate.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react';
-import { useNavigate } from 'react-router-dom';
 import {
   ApiError,
   BookCoversService,
@@ -8,11 +6,13 @@ import {
   type BookRequest,
   type BookResponse,
 } from '@/api';
-import { getErrorMessage } from '@/utils/error';
-import { validateBook, parseFieldErrors } from './bookValidation';
-import { useNotifications } from '@/hooks/useNotifications/useNotifications';
-import BookForm, { type BookFormState, type FormFieldValue } from './BookForm';
 import PageContainer from '@/components/PageContainer';
+import { useNotifications } from '@/hooks/useNotifications/useNotifications';
+import { getErrorMessage } from '@/utils/error';
+import * as React from 'react';
+import { useNavigate } from 'react-router-dom';
+import BookForm, { type BookFormState, type FormFieldValue } from './BookForm';
+import { parseFieldErrors, validateBook } from './bookValidation';
 
 const INITIAL_FORM_VALUES: Partial<BookFormState['values']> = {
   distributorAuthorRoyaltyRate: 0.5,
@@ -21,6 +21,7 @@ const INITIAL_FORM_VALUES: Partial<BookFormState['values']> = {
   publicationMonth: 1,
   coverPrice: 0,
   printCost: 0,
+  released: true,
 };
 
 export default function BookCreate() {
@@ -188,6 +189,9 @@ export default function BookCreate() {
         coverPrice: formValues.coverPrice ?? 0,
         printCost: formValues.printCost ?? 0,
         amazonEbookAsin: formValues.amazonEbookAsin ?? undefined,
+        released: formValues.released ?? true,
+        kickstarterItemTagEbook: formValues.kickstarterItemTagEbook ?? undefined,
+        kickstarterItemTagPrint: formValues.kickstarterItemTagPrint ?? undefined,
         coverImage: formValues.coverImage ?? undefined,
       };
       const book: BookResponse = await BooksService.createBook(request);

--- a/frontend/src/features/books/BookEdit.tsx
+++ b/frontend/src/features/books/BookEdit.tsx
@@ -1,21 +1,21 @@
-import Alert from '@mui/material/Alert';
-import * as React from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
-import FullPageLoader from '@/components/FullPageLoader';
 import {
   AuthorsService,
-  BooksService,
   BookCoversService,
+  BooksService,
   type AuthorResponse,
   type BookRequest,
   type BookResponse,
 } from '@/api';
+import FullPageLoader from '@/components/FullPageLoader';
+import PageContainer from '@/components/PageContainer';
+import { useNotifications } from '@/hooks/useNotifications/useNotifications';
 import { getErrorMessage } from '@/utils/error';
 import { truncate } from '@/utils/formatting';
-import { validateBook, parseFieldErrors } from './bookValidation';
-import { useNotifications } from '@/hooks/useNotifications/useNotifications';
+import Alert from '@mui/material/Alert';
+import * as React from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
 import BookForm, { type BookFormState, type FormFieldValue } from './BookForm';
-import PageContainer from '@/components/PageContainer';
+import { parseFieldErrors, validateBook } from './bookValidation';
 
 const normalizeRoyaltyRate = (value: unknown, fallback: number) => {
   if (value == null || value === '') return fallback;
@@ -215,6 +215,9 @@ export default function BookEdit() {
         coverPrice: formValues.coverPrice ?? 0,
         printCost: formValues.printCost ?? 0,
         amazonEbookAsin: formValues.amazonEbookAsin ?? undefined,
+        released: formValues.released ?? true,
+        kickstarterItemTagEbook: formValues.kickstarterItemTagEbook ?? undefined,
+        kickstarterItemTagPrint: formValues.kickstarterItemTagPrint ?? undefined,
       };
       const updatedData = await BooksService.updateBook(Number(bookId), request);
       setBook(updatedData);

--- a/frontend/src/features/books/BookForm.tsx
+++ b/frontend/src/features/books/BookForm.tsx
@@ -7,12 +7,14 @@ import Autocomplete from '@mui/material/Autocomplete';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import CircularProgress from '@mui/material/CircularProgress';
+import FormControlLabel from '@mui/material/FormControlLabel';
 import FormGroup from '@mui/material/FormGroup';
 import Grid from '@mui/material/Grid';
 import IconButton from '@mui/material/IconButton';
 import InputAdornment from '@mui/material/InputAdornment';
 import MenuItem from '@mui/material/MenuItem';
 import Stack from '@mui/material/Stack';
+import Switch from '@mui/material/Switch';
 import TextField from '@mui/material/TextField';
 import Tooltip from '@mui/material/Tooltip';
 import * as React from 'react';
@@ -142,6 +144,13 @@ export default function BookForm(props: BookFormProps) {
         event.target.name as keyof BookFormState['values'],
         value === '' ? null : Number(value),
       );
+    },
+    [onFieldChange],
+  );
+
+  const handleSwitchChange = React.useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      onFieldChange(event.target.name as keyof BookFormState['values'], event.target.checked);
     },
     [onFieldChange],
   );
@@ -278,6 +287,18 @@ export default function BookForm(props: BookFormProps) {
               fullWidth
             />
           </Grid>
+          <Grid size={{ xs: 12, sm: 6 }} sx={{ display: 'flex', alignItems: 'center' }}>
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={formValues.released ?? true}
+                  onChange={handleSwitchChange}
+                  name="released"
+                />
+              }
+              label="Released"
+            />
+          </Grid>
           <Grid size={{ xs: 12, sm: 6 }} sx={{ display: 'flex' }}>
             <TextField
               type="number"
@@ -329,11 +350,37 @@ export default function BookForm(props: BookFormProps) {
           </Grid>
           <Grid size={{ xs: 12, sm: 6 }} sx={{ display: 'flex' }}>
             <TextField
+              value={formValues.kickstarterItemTagEbook ?? ''}
+              onChange={handleTextFieldChange}
+              name="kickstarterItemTagEbook"
+              label="Kickstarter Item Tag (Ebook)"
+              error={!!formErrors.kickstarterItemTagEbook}
+              helperText={
+                formErrors.kickstarterItemTagEbook ?? 'Optional, max 128 chars, no spaces'
+              }
+              fullWidth
+            />
+          </Grid>
+          <Grid size={{ xs: 12, sm: 6 }} sx={{ display: 'flex' }}>
+            <TextField
+              value={formValues.kickstarterItemTagPrint ?? ''}
+              onChange={handleTextFieldChange}
+              name="kickstarterItemTagPrint"
+              label="Kickstarter Item Tag (Print)"
+              error={!!formErrors.kickstarterItemTagPrint}
+              helperText={
+                formErrors.kickstarterItemTagPrint ?? 'Optional, max 128 chars, no spaces'
+              }
+              fullWidth
+            />
+          </Grid>
+          <Grid size={{ xs: 12, sm: 6 }} sx={{ display: 'flex' }}>
+            <TextField
               type="number"
               value={formatRoyaltyRateForInput(formValues.handsoldAuthorRoyaltyRate)}
               onChange={handleRoyaltyFieldChange}
               name="handsoldAuthorRoyaltyRate"
-              label="Handsold Royalty Rate (%)"
+              label="Handsold/Kickstarter Royalty Rate (%)"
               error={!!formErrors.handsoldAuthorRoyaltyRate}
               helperText={
                 formErrors.handsoldAuthorRoyaltyRate ?? 'Enter a percentage from 0 to 100'

--- a/frontend/src/features/books/bookValidation.ts
+++ b/frontend/src/features/books/bookValidation.ts
@@ -99,6 +99,46 @@ export function validateBook(book: Partial<BookResponse>): ValidationResult {
     ];
   }
 
+  if (book.kickstarterItemTagEbook) {
+    if (/\s/.test(book.kickstarterItemTagEbook)) {
+      issues = [
+        ...issues,
+        {
+          message: 'Kickstarter ebook tag must not contain whitespace',
+          path: ['kickstarterItemTagEbook'],
+        },
+      ];
+    } else if (book.kickstarterItemTagEbook.length > 128) {
+      issues = [
+        ...issues,
+        {
+          message: 'Kickstarter ebook tag must be at most 128 characters',
+          path: ['kickstarterItemTagEbook'],
+        },
+      ];
+    }
+  }
+
+  if (book.kickstarterItemTagPrint) {
+    if (/\s/.test(book.kickstarterItemTagPrint)) {
+      issues = [
+        ...issues,
+        {
+          message: 'Kickstarter print tag must not contain whitespace',
+          path: ['kickstarterItemTagPrint'],
+        },
+      ];
+    } else if (book.kickstarterItemTagPrint.length > 128) {
+      issues = [
+        ...issues,
+        {
+          message: 'Kickstarter print tag must be at most 128 characters',
+          path: ['kickstarterItemTagPrint'],
+        },
+      ];
+    }
+  }
+
   return { issues };
 }
 

--- a/frontend/src/features/sales/SaleEdit.tsx
+++ b/frontend/src/features/sales/SaleEdit.tsx
@@ -169,7 +169,7 @@ export default function SaleEdit() {
           format,
           saleMonth,
           saleYear,
-          quantitySold: format === SaleRequest.format.KINDLE_UNLIMITED ? 0 : quantitySold,
+          quantitySold: format === SaleRequest.format.KINDLE_UNLIMITED ? undefined : quantitySold,
           kenp: format === SaleRequest.format.KINDLE_UNLIMITED ? kenp : undefined,
           saleCurrency:
             saleSource === SaleRequest.saleSource.HAND_SOLD

--- a/frontend/src/features/sales/SaleList.tsx
+++ b/frontend/src/features/sales/SaleList.tsx
@@ -24,6 +24,7 @@ import { useNotifications } from '@/hooks/useNotifications/useNotifications';
 import { useServerDataGrid } from '@/hooks/useServerDataGrid';
 import { getErrorMessage } from '@/utils/error';
 import { formatCurrency, formatCurrencyWithCode, formatMonthYear } from '@/utils/formatting';
+import type { GridRowClassNameParams } from '@mui/x-data-grid';
 import {
   GridActionsCellItem,
   type GridColDef,
@@ -53,6 +54,7 @@ export default function SaleList() {
   const [saleSource, setSaleSource] = React.useState<string>('all');
   const [format, setFormat] = React.useState<string>('all');
   const [distributor, setDistributor] = React.useState<string>('all');
+  const [projectedStatus, setProjectedStatus] = React.useState<string>('all');
   const [authors, setAuthors] = React.useState<AuthorResponse[]>([]);
 
   const fetchFn = React.useCallback(
@@ -78,6 +80,8 @@ export default function SaleList() {
         format === 'all'
           ? undefined
           : (format.toUpperCase() as 'PRINT' | 'EBOOK' | 'KINDLE_UNLIMITED');
+      const isProjectedParam =
+        projectedStatus === 'all' ? undefined : projectedStatus === 'projected';
 
       return SalesService.getSales(
         params.page,
@@ -91,9 +95,19 @@ export default function SaleList() {
         saleSourceParam,
         distributorParam,
         formatParam,
+        isProjectedParam,
       );
     },
-    [sortModel, startDate, endDate, selectedAuthor, saleSource, distributor, format],
+    [
+      sortModel,
+      startDate,
+      endDate,
+      selectedAuthor,
+      saleSource,
+      distributor,
+      format,
+      projectedStatus,
+    ],
   );
 
   const {
@@ -150,8 +164,10 @@ export default function SaleList() {
     if (saleSource !== 'all') params.set('saleSource', saleSource.toUpperCase());
     if (distributor !== 'all') params.set('distributor', distributor.toUpperCase());
     if (format !== 'all') params.set('format', format.toUpperCase());
+    if (projectedStatus === 'projected') params.set('isProjected', 'true');
+    if (projectedStatus === 'actual') params.set('isProjected', 'false');
     window.open(`/api/sales/export?${params.toString()}`, '_blank');
-  }, [startDate, endDate, selectedAuthor, saleSource, distributor, format]);
+  }, [startDate, endDate, selectedAuthor, saleSource, distributor, format, projectedStatus]);
 
   const handleRowDelete = React.useCallback(
     (sale: SaleResponse) => async () => {
@@ -199,6 +215,7 @@ export default function SaleList() {
         renderCell: (params) => {
           const bookId = params.row.bookId;
           const title = params.row.bookTitle;
+          const isProjected = params.row.isProjected;
 
           return (
             <Link
@@ -206,6 +223,7 @@ export default function SaleList() {
               style={{
                 color: 'inherit',
                 textDecoration: 'none',
+                opacity: isProjected ? 0.5 : 1,
               }}
               onMouseEnter={(e) => {
                 e.currentTarget.style.textDecoration = 'underline';
@@ -366,6 +384,13 @@ export default function SaleList() {
 
   const pageTitle = 'Records';
 
+  const getRowClassName = React.useCallback((params: GridRowClassNameParams<SaleResponse>) => {
+    if (params.row?.isProjected) {
+      return 'projected-row';
+    }
+    return '';
+  }, []);
+
   return (
     <PageContainer
       title={pageTitle}
@@ -381,6 +406,18 @@ export default function SaleList() {
               <Button onClick={handleExportClick}>Export</Button>
             </ButtonGroup>
           </Box>
+
+          <Stack
+            direction="row"
+            alignItems="center"
+            spacing={0.75}
+            flexWrap="wrap"
+            useFlexGap
+            sx={{ fontSize: '0.875rem', color: 'text.secondary' }}
+          >
+            <span style={{ opacity: 0.5 }}>●</span>
+            <span>Greyed out records are projected sales (unreleased books)</span>
+          </Stack>
 
           <Stack direction="row" alignItems="center" spacing={0.75} flexWrap="wrap" useFlexGap>
             <Tooltip title="Reload data" placement="bottom" enterDelay={1000}>
@@ -465,6 +502,20 @@ export default function SaleList() {
                 <MenuItem value="all">All</MenuItem>
                 <MenuItem value="distributor">Distributor</MenuItem>
                 <MenuItem value="hand_sold">Hand Sold</MenuItem>
+                <MenuItem value="kickstarter">Kickstarter</MenuItem>
+              </Select>
+            </FormControl>
+
+            <FormControl size="small" sx={{ minWidth: 130 }}>
+              <InputLabel>Projected Status</InputLabel>
+              <Select
+                value={projectedStatus}
+                label="Projected Status"
+                onChange={(e: SelectChangeEvent) => setProjectedStatus(e.target.value)}
+              >
+                <MenuItem value="all">All Sales</MenuItem>
+                <MenuItem value="actual">Actual Only</MenuItem>
+                <MenuItem value="projected">Projected Only</MenuItem>
               </Select>
             </FormControl>
 
@@ -512,6 +563,12 @@ export default function SaleList() {
           onPaginationModelChange={onPaginationModelChange}
           sortModel={sortModel}
           onSortModelChange={setSortModel}
+          getRowClassName={getRowClassName}
+          sx={{
+            '& .projected-row': {
+              opacity: 0.55,
+            },
+          }}
         />
       </Box>
     </PageContainer>

--- a/frontend/src/features/sales/SaleShow.tsx
+++ b/frontend/src/features/sales/SaleShow.tsx
@@ -236,6 +236,15 @@ export default function SaleShow() {
               label={formatLabel}
               sx={{ fontWeight: 500, borderColor: 'divider', color: 'text.secondary' }}
             />
+            {sale.isProjected && (
+              <Chip
+                size="small"
+                variant="outlined"
+                label="Projected (Not Eligible)"
+                color="warning"
+                sx={{ fontWeight: 600 }}
+              />
+            )}
             {isDistributor && (
               <Chip
                 size="small"
@@ -410,6 +419,25 @@ export default function SaleShow() {
                 </Typography>
                 <Box sx={{ mt: 0.75 }}>
                   <PaidStatusChip paid={sale.hasAuthorBeenPaid} />
+                </Box>
+              </Box>
+
+              <Box>
+                <Typography
+                  variant="caption"
+                  color="text.secondary"
+                  sx={{ fontWeight: 600, textTransform: 'uppercase', letterSpacing: 0.5 }}
+                >
+                  Projected Status
+                </Typography>
+                <Box sx={{ mt: 0.75 }}>
+                  {sale.isProjected ? (
+                    <Alert severity="warning" sx={{ py: 0.5 }}>
+                      Projected sale for an unreleased book. Royalty is not eligible for payout yet.
+                    </Alert>
+                  ) : (
+                    <Chip size="small" label="Actual Sale" color="success" variant="outlined" />
+                  )}
                 </Box>
               </Box>
             </Stack>


### PR DESCRIPTION


## What Changed

### Backend
- Added projected status support in sales API responses and filters
  - Added isProjected to sale response models
  - Added optional isProjected filtering for sales list/export endpoints
- Updated author payment grouping
  - Added projectedUnpaidTotal
  - Added per-sale projected flag in author payment rows
- Updated mark-all-paid behavior
  - Marks only non-projected unpaid sales as paid
- Updated royalties/totals to exclude projected for primary totals
  - Author aggregate totals now exclude unreleased book sales
  - Book financial summary royalty/revenue totals used by author detail views exclude unreleased sales
- Updated report logic to exclude projected sales in primary calculations
  - Author royalty report generation excludes projected sales
  - All Authors Royalty, Publisher Profit, and Amazon Sales report paths filter unreleased/projected data
- Unified projected detection to use the Book Released flag

### Frontend
- Sales list
  - Added projected status filter (all, actual only, projected only)
  - Added visual treatment for projected rows (greyed/de-emphasized)
  - Updated export to carry projected filter
- Sales detail
  - Added projected status indicator and payout-eligibility messaging
- Sales edit
  - Fixed Kindle Unlimited payload mismatch that caused update 400 errors
- Author payments
  - Added projected unpaid subtotal per author
  - Kept non-projected unpaid total as primary payout amount
  - Confirmation and mark-paid actions now clearly target non-projected unpaid records
  - Added PayPal and Venmo links using non-projected unpaid totals
  - Venmo link includes note Author royalty
  - External payment links open in a new tab, with no payment-status integration
- Author list and author detail
  - Clarified that displayed primary royalty totals exclude projected sales
- Book create/edit forms
  - Added Released input and Kickstarter item tag inputs
  - Kept royalty defaults at 50 percent distributor and 20 percent handsold/Kickstarter
  - Added ISBN lookup improvements and related form validation updates


- Updated the book creation form label and wording to explicitly use “Handsold/Kickstarter” royalty terminology for clarity and requirement alignment.
- Added visual treatment for projected sales in the sales listing so projected records are clearly de-emphasized (greyed out).
- Expanded sales filtering to support:
- sale source: Distributor, Handsold, Kickstarter, All
- Projected status filtering (Actual / Projected / All)
- Updated Author Payments view to:
- show a separate projected-sales subtotal (not payout-eligible)
- include PayPal and Venmo payout links for authors



